### PR TITLE
Latest French translation - Consolidation

### DIFF
--- a/src/main/java/Bundle_fr.properties
+++ b/src/main/java/Bundle_fr.properties
@@ -56,20 +56,20 @@ previous=Précédent
 next=Suivant
 first=Premier
 last=Dernier
-more=Plus...
-less=Moins...
-select=Sélectionner...
+more=Plus\u2026
+less=Moins\u2026
+select=Sélectionner\u2026
 selectedFiles=Fichiers sélectionnés
 htmlAllowedTitle=Balises HTML permises
-htmlAllowedMsg=Ce champ prend seulement en charge certaines <span class="text-info popoverHTML">balises HTML</span>.
+htmlAllowedMsg=Ce champ prend en charge uniquement certaines <span class="text-info popoverHTML">balises HTML</span>.
 htmlAllowedTags=<a>, <b>, <blockquote>, <br>, <code>, <del>, <dd>, <dl>, <dt>, <em>, <hr>, <h1>-<h3>, <i>, <img>, <kbd>, <li>, <ol>, <p>, <pre>, <s>, <sup>, <sub>, <strong>, <strike>, <ul>
-toggleNavigation=Toggle navigation
-defaultBody=Default Body
-filter=Filter
+toggleNavigation=Basculer la navigation
+defaultBody=Corps du texte par défaut
+filter=Filtre
 
-# dataverse_header.xhtml=
+# dataverse_header.xhtml
 header.status.header=État
-header.search.title=Chercher dans tous les dataverses...
+header.search.title=Chercher dans tous les dataverses\u2026
 header.about=À propos
 header.support=Soutien
 header.guides=Guides
@@ -92,9 +92,9 @@ header.user.selectTab.apiToken=Jeton API
 head.meta.description=Dataverse est un logiciel libre pour le partage, la citation et l'archivage de données. Dataverse fournit aux gestionnaires de données une infrastructure solide pour héberger et archiver des données et offre aux chercheurs une solution pour partager facilement leurs données et en obtenir le crédit.
 body.skip=Passer au contenu principal
 
-# dataverse_footer.xhtml
-footer.copyright=Droits réservés &#169; {0}
-footer.widget.datastored=Les données sont archivées par: {0}.
+# dataverse_footer.xhtml=
+footer.copyright=Droits réservés \u00a9 {0}
+footer.widget.datastored=Les données sont archivées par\u00A0: {0}.
 footer.widget.login=Se connecter à
 footer.privacyPolicy=Politique de protection de la vie privée
 footer.poweredby=Fourni par
@@ -107,7 +107,7 @@ messages.info=Info
 messages.validation=Erreur de validation
 messages.validation.msg=Des champs requis sont manquants ou encore une erreur de validation est survenue. Faites défiler vers le bas pour voir les détails.
 
-# contactFormFragment.xhtml
+# contactFormFragment.xhtml=
 contact.header=Personne-ressource pour {0}
 contact.dataverse.header=Communiquer avec la personne-ressource pour ce dataverse
 contact.dataset.header=Communiquer avec la personne-ressource pour cet ensemble de données
@@ -118,7 +118,7 @@ contact.from.required=L'adresse courriel de l'utilisateur est requise.
 contact.from.invalid=L'adresse courriel est invalide.
 contact.subject=Objet
 contact.subject.required=Il faut indiquer un objet
-contact.subject.selectTab.top=Sélectionner l'objet...
+contact.subject.selectTab.top=Sélectionner l'objet\u2026
 contact.subject.selectTab.support=Question de soutien
 contact.subject.selectTab.dataIssue=Problème concernant les données
 contact.msg=Message
@@ -130,22 +130,22 @@ contact.sum.invalid=Somme incorrecte, veuillez réessayer.
 contact.sum.converterMessage=Veuillez entrer un chiffre.
 contact.contact=Personne-ressource
 # Bundle file editors, please note that these "contact.context" messages are used in tests.
-contact.context.subject.dvobject={0} contact: {1}
-contact.context.subject.support={0} support request: {1}
-contact.context.dataverse.intro={0}You have just been sent the following message from {1} via the {2} hosted dataverse named "{3}":\n\n---\n\n
-contact.context.dataverse.ending=\n\n---\n\n{0}\n{1}\n\nGo to dataverse {2}/dataverse/{3}\n\nYou received this email because you have been listed as a contact for the dataverse. If you believe this was an error, please contact {4} at {5}. To respond directly to the individual who sent the message, simply reply to this email.
-contact.context.dataverse.noContact=There is no contact address on file for this dataverse so this message is being sent to the system address.\n\n
-contact.context.dataset.greeting.helloFirstLast=Hello {0} {1},
-contact.context.dataset.greeting.organization=Attention Dataset Contact:
-contact.context.dataset.intro={0}\n\nYou have just been sent the following message from {1} via the {2} hosted dataset titled "{3}" ({4}):\n\n---\n\n
-contact.context.dataset.ending=\n\n---\n\n{0}\n{1}\n\nGo to dataset {2}/dataset.xhtml?persistentId={3}\n\nYou received this email because you have been listed as a contact for the dataset. If you believe this was an error, please contact {4} at {5}. To respond directly to the individual who sent the message, simply reply to this email.
-contact.context.dataset.noContact=There is no contact address on file for this dataset so this message is being sent to the system address.\n\n---\n\n
-contact.context.file.intro={0}\n\nYou have just been sent the following message from {1} via the {2} hosted file named "{3}" from the dataset titled "{4}" ({5}):\n\n---\n\n
-contact.context.file.ending=\n\n---\n\n{0}\n{1}\n\nGo to file {2}/file.xhtml?fileId={3}\n\nYou received this email because you have been listed as a contact for the dataset. If you believe this was an error, please contact {4} at {5}. To respond directly to the individual who sent the message, simply reply to this email.
-contact.context.support.intro={0},\n\nThe following message was sent from {1}.\n\n---\n\n
-contact.context.support.ending=\n\n---\n\nMessage sent from Support contact form.
+contact.context.subject.dvobject={0} Personne-ressource\u00A0: {1}
+contact.context.subject.support={0} Demande de soutien\u00A0: {1}
+contact.context.dataverse.intro={0}Vous venez de recevoir le message suivant de {1} via le dataverse hébergé {2} nommé «\u00A0{3}\u00A0»\u00A0:\n\n---\n\n
+contact.context.dataverse.ending=\n\n---\n\n{0}\n{1}\n\nAccéder au dataverse {2}/dataverse/{3}\n\nVous avez reçu ce courriel car vous avez été enregistré en tant que personne-contact pour le dataverse. Si vous pensez qu'il s'agit d'une erreur, veuillez contacter {4} à {5}. Pour répondre directement à la personne qui a envoyé le message, répondez simplement à ce courriel.
+contact.context.dataverse.noContact=Il n'y a pas d'adresse de contact enregistrée pour ce dataverse. Par conséquent ce message est envoyé à l'adresse du système.\n\n
+contact.context.dataset.greeting.helloFirstLast=Bonjour {0} {1},
+contact.context.dataset.greeting.organization=À l'attention de la personne-contact de l'ensemble de données\u00A0:
+contact.context.dataset.intro={0}\n\nVous venez de recevoir le message suivant de {1} via l'ensemble de données hébergé {2} nommé «\u00A0{3}\u00A0» ({4})\u00A0:\n\n---\n\n
+contact.context.dataset.ending=\n\n---\n\n{0}\n{1}\n\nAccéder à l'ensemble de données {2}/dataset.xhtml?persistentId={3}\n\nVous avez reçu ce courriel car vous avez été enregistré en tant que personne-contact pour l'ensemble de données. Si vous pensez qu'il s'agit d'une erreur, veuillez contacter {4} à {5}. Pour répondre directement à la personne qui a envoyé le message, répondez simplement à ce courriel.
+contact.context.dataset.noContact=Il n'y a pas d'adresse de contact enregistrée pour ce ensemble de données. Par conséquent ce message est envoyé à l'adresse du système.\n\n---\n\n
+contact.context.file.intro={0}\n\nVous venez de recevoir le message suivant de {1} via le fichier hébergé {2} nommé «\u00A0{3}\u00A0» provenant de l'ensemble de données nommé «\u00A0{4}\u00A0» ({5})\u00A0:\n\n---\n\n
+contact.context.file.ending=\n\n---\n\n{0}\n{1}\n\nAccéder au fichier {2}/file.xhtml?fileId={3}\n\nVous avez reçu ce courriel car vous avez été enregistré en tant que personne-contact pour l'ensemble de données. Si vous pensez qu'il s'agit d'une erreur, veuillez contacter {4} à {5}. Pour répondre directement à la personne qui a envoyé le message, répondez simplement à ce courriel.
+contact.context.support.intro={0},\n\nLe message suivant a été envoyé depuis {1}.\n\n---\n\n
+contact.context.support.ending=\n\n---\n\nMessage envoyé depuis le formulaire de demande de soutien.
 
-# dataverseuser.xhtml=
+# dataverseuser.xhtml
 account.info=Renseignements sur le compte
 account.edit=Modifier le compte
 account.apiToken=Jeton API
@@ -154,7 +154,7 @@ user.helpShibUserMigrateOffShibBeforeLink=Vous quittez votre établissement? Priè
 user.helpShibUserMigrateOffShibAfterLink=pour obtenir de l'aide.
 user.helpOAuthBeforeLink=Votre compte Dataverse utilise {0} pour pouvoir se connecter. Si vous souhaitez modifier vos modes de connexion, prière de contacter
 user.helpOAuthAfterLink=pour obtenir du soutien.
-user.lostPasswdTip=Si vous avez perdu ou oublié votre mot de passe, indiquez votre nom d'utilisateur ou votre adresse courriel dans l'espace ci-dessous et cliquez sur «Soumettre». Nous vous enverrons votre nouveau mot de passe par courriel.
+user.lostPasswdTip=Si vous avez perdu ou oublié votre mot de passe, indiquez votre nom d'utilisateur ou votre adresse courriel dans l'espace ci-dessous et cliquez sur «\u00A0Soumettre\u00A0». Nous vous enverrons votre nouveau mot de passe par courriel.
 user.dataRelatedToMe=Mes données
 wasCreatedIn=a été créé dans
 wasCreatedTo=a été ajouté à
@@ -165,20 +165,20 @@ wasReturnedByReviewer=a été retourné par l'intendant des données de
 toReview=N'oubliez pas de les publier ou de les renvoyer au collaborateur!
 worldMap.added=Les données d'une couche WorldMap ont été ajoutées à l'ensemble de données.
 # Bundle file editors, please note that "notification.welcome" is used in a unit test.=
-notification.welcome=Bienvenue dans le {0}! Commencez dès maintenant en ajoutant ou encore en recherchant des données. Des questions? Consultez le: {1}. Vous voulez faire l'essai des composantes de Dataverse? Essayez notre {2}.  N'oubliez pas de vérifier que vous avez bien reçu votre courriel d'invitation afin que nous puissions valider votre adresse.
+notification.welcome=Bienvenue dans le {0}! Commencez dès maintenant en ajoutant ou encore en recherchant des données. Des questions? Consultez le\u00A0: {1}. Vous voulez faire l'essai des composantes de Dataverse? Essayez notre {2}.  N'oubliez pas de vérifier que vous avez bien reçu votre courriel d'invitation afin que nous puissions valider votre adresse.
 notification.demoSite=Site de démonstration
-notification.requestFileAccess=Demande d'accès pour l'ensemble de données: {0}.
-notification.grantFileAccess=Accès accordé pour les fichiers de l'ensemble de données: {0}.
-notification.rejectFileAccess=Demande d'accès refusée pour les fichiers de l'ensemble de données: {0}.
+notification.requestFileAccess=Demande d'accès pour l'ensemble de données\u00A0: {0}.
+notification.grantFileAccess=Accès accordé pour les fichiers de l'ensemble de données\u00A0: {0}.
+notification.rejectFileAccess=Demande d'accès refusée pour les fichiers de l'ensemble de données\u00A0: {0}.
 notification.createDataverse={0}  a été créé dans {1}. Pour savoir ce que vous pouvez faire avec votre dataverse, consultez le {2}.
-notification.dataverse.management.title=Administration de Dataverse - Guide d'utilisation Dataverse
+notification.dataverse.management.title=Administration de Dataverse - Guide d'utilisation de Dataverse
 notification.createDataset={0}  a été créé dans {1}. Pour savoir ce que vous pouvez faire avec votre ensemble de données, consultez le {2}.
 notification.dataset.management.title=Administration des ensembles de données - Guide d'utilisation pour les ensembles de données
 notification.wasSubmittedForReview={0} a été soumis pour vérification avant publication dans {1}. N'oubliez pas de le publier ou de le renvoyer au collaborateur\!
 notification.wasReturnedByReviewer={0} a été retourné par l'intendant des données de {1}.
 notification.wasPublished={0} a été publié dans {1}.
 notification.worldMap.added={0}, cet ensemble de données dispose maintenant d'une couche de données WorldMap.
-notification.maplayer.deletefailed=Impossible de supprimer la couche cartographique associée au fichier à accès restreint {0} provenant de WorldMap. Essayez de nouveau, ou contactez le soutien WorldMap et/ou Dataverse. (Ensemble de données: {1})
+notification.maplayer.deletefailed=Impossible de supprimer la couche cartographique associée au fichier à accès restreint {0} provenant de WorldMap. Essayez de nouveau, ou contactez le soutien WorldMap et/ou Dataverse. (Ensemble de données\u00A0: {1})
 notification.generic.objectDeleted=Le dataverse, l'ensemble de données ou le fichier visé par cet avis a été supprimé. 
 notification.access.granted.dataverse=Le rôle {0} vous a été accordé pour {1}.
 notification.access.granted.dataset=Le rôle {0} vous a été accordé pour {1}.
@@ -196,7 +196,7 @@ removeNotification=Supprimer l'avis
 groupAndRoles.manageTips=Vous pouvez gérer tous les groupes dont vous êtes membre et les rôles qui vous ont été confiés et y avoir accès.
 user.signup.tip=Pourquoi se créer un compte Dataverse? De façon à pouvoir créer votre propre dataverse, le personnaliser, y ajouter des ensembles de données, ou encore pour demander l'accès à des fichiers à accès réservé. 
 user.signup.otherLogInOptions.tip=<a href="/loginpage.xhtml" title="Dataverse - Se connecter">Voir les autres options de connexion.</a>
-user.username.illegal.tip=Votre nom d'utilisateur doit compter entre 2 et 60caractères et vous pouvez utiliser les lettres a à z, les chiffres 0 à 9 et le caractère souligné «_».
+user.username.illegal.tip=Votre nom d'utilisateur doit compter entre 2 et 60\u00A0caractères et vous pouvez utiliser les lettres a à z, les chiffres 0 à 9 et le caractère souligné «\u00A0_\u00A0».
 user.username=Nom d'utilisateur
 user.username.taken=Ce nom d'utilisateur est déjà pris.
 user.username.invalid=Ce nom d'utilisateur contient un caractère invalide ou enfreint la limite de longueur (2 à 60 caractères).
@@ -215,7 +215,7 @@ user.email.tip=Une adresse courriel valide permettant de communiquer avec vous.
 user.email.taken=Cette adresse courriel est déjà prise.
 user.affiliation.tip=L'organisation avec laquelle vous êtes affilié(e).
 user.position=Poste
-user.position.tip=Votre rôle ou titre au sein de l'organisation avec laquelle vous êtes affilié(e), par exemple: employé(e), membre du corps professoral, étudiant(e), etc. 
+user.position.tip=Votre rôle ou titre au sein de l'organisation avec laquelle vous êtes affilié(e), par exemple\u00A0: employé(e), membre du corps professoral, étudiant(e), etc. 
 user.acccountterms=Conditions générales d'utilisation
 user.acccountterms.tip=Les conditions d'utilisation de l'application et des services.
 user.acccountterms.required=Veuillez cocher la case pour indiquer que vous acceptez les conditions générales d'utilisation.
@@ -224,22 +224,22 @@ user.createBtn=Créer un compte
 user.updatePassword.welcome=Bienvenue dans Dataverse, {1}
 user.updatePassword.warning=Les exigences relatives au mot de passe et les conditions générales d'utilisation ont été mises à jour lors de la publication de notre nouvelle version de Dataverse 4.0. Comme c'est la première fois que vous utilisez Dataverse depuis la mise à jour, vous devez créer un nouveau mot de passe et accepter les nouvelles conditions générales d'utilisation.
 user.updatePassword.password={0}
-user.password=Password
-user.newPassword=New Password
+user.password=Mot de passe
+user.newPassword=Nouveau mot de passe
 authenticationProvidersAvailable.tip={0}Il n'y a aucun système d'authentification actif{1}Si vous êtes administrateur système, veuillez en autoriser un au moyen de l'API.{2}Si vous n'êtes pas administrateur système, veuillez communiquer avec celui de votre établissement. 
 
-passwdVal.passwdReq.title=Votre mot de passe doit contenir:
+passwdVal.passwdReq.title=Votre mot de passe doit contenir\u00A0:
 passwdVal.passwdReq.goodStrength =Les mots de passe d'un minimum de {0} caractères sont exempts de tout autre exigence
 passwdVal.passwdReq.lengthReq =Au minimum {0} caractères 
-passwdVal.passwdReq.characteristicsReq =Au moins un caractère provenant de {0} des types suivants:
-passwdVal.passwdReq.notInclude =Il ne doit pas contenir:
+passwdVal.passwdReq.characteristicsReq =Au moins un caractère provenant de {0} des types suivants\u00A0:
+passwdVal.passwdReq.notInclude =Il ne doit pas contenir\u00A0:
 passwdVal.passwdReq.consecutiveDigits =Plus de {0} chiffres consécutifs
 passwdVal.passwdReq.dictionaryWords =Des mots du dictionnaire
 passwdVal.passwdReq.unknownPasswordRule =Inconnu, contactez votre administrateur
 #printf syntax used to pass to passay library
 passwdVal.expireRule.errorCode =EXPIRÉ
 passwdVal.expireRule.errorMsg =Le mot de passe date de plus de %1$s jours et est expiré.
-passwdVal.goodStrengthRule.errorMsg =Remarque: les mots de passe d'une longueur de %1$s caractères ou plus restent toujours valides.
+passwdVal.goodStrengthRule.errorMsg =Remarque\u00A0: les mots de passe d'une longueur de %1$s caractères ou plus restent toujours valides.
 passwdVal.goodStrengthRule.errorCode =PEU SÛR
 passwdVal.passwdReset.resetLinkTitle =Lien pour la réinitialisation du mot de passe
 passwdVal.passwdReset.resetLinkDesc =Le lien de réinitialisation de votre mot de passe n'est pas valide
@@ -281,8 +281,8 @@ auth.providers.persistentUserIdName.github=Identifiant GitHub
 auth.providers.persistentUserIdTooltip.orcid=ORCID fournit un identifiant numérique pérenne qui vous distingue des autres chercheurs.
 auth.providers.persistentUserIdTooltip.github=GitHub attribue un identifiant unique à chaque utilisateur.
 auth.providers.orcid.insufficientScope=Dataverse n'a pas reçu l'autorisation de lire les données utilisateur de ORCID.
-auth.providers.orcid.helpmessage1=ORCID is an open, non-profit, community-based effort to provide a registry of unique researcher identifiers and a transparent method of linking research activities and outputs to these identifiers. ORCID is unique in its ability to reach across disciplines, research sectors, and national boundaries and its cooperation with other identifier systems. Find out more at <a href="https://orcid.org/about" target="_blank">orcid.org/about</a>.
-auth.providers.orcid.helpmessage2=This repository uses your ORCID for authentication (so you don't need another username/password combination).  Having your ORCID associated with your datasets also makes it easier for people to find the datasets you have published.  
+auth.providers.orcid.helpmessage1=ORCID est une initiative communautaire, ouverte et sans but lucratif visant à fournir un registre d'identifiants uniques de chercheurs ainsi qu'une méthode transparente pour lier les activités et produits de la recherche à ces identifiants. ORCID est unique dans sa capacité à atteindre les intervenants de toutes disciplines, secteurs de recherche et frontières nationales confondus ainsi que de coopérer avec d'autres systèmes d'identifiants. Pour en savoir davantage visitez <a href="https://orcid.org/about" target="_blank">orcid.org/about</a>.
+auth.providers.orcid.helpmessage2=Ce dépôt utilise votre identifiant ORCID pour l'authentification (vous n'avez donc pas besoin d'une autre combinaison nom d'utilisateur / mot de passe). Le fait que votre ORCID soit associé à vos ensembles de données facilite également la recherche des ensembles de données que vous avez publiés.
 
 # Friendly AuthenticationProvider names
 authenticationProvider.name.builtin=Dataverse
@@ -293,12 +293,12 @@ authenticationProvider.name.orcid=ORCID
 authenticationProvider.name.orcid-sandbox=Bac à sable ORCID
 authenticationProvider.name.shib=Shibboleth
 
-#confirmemail.xhtml
+#confirmemail.xhtml=
 confirmEmail.pageTitle=Validation du courriel
 confirmEmail.submitRequest=Valider le courriel
 confirmEmail.submitRequest.success=Un courriel de validation a été envoyé à {0}. Veuillez noter que le lien de validation expirera après un délai de {1}.
 confirmEmail.details.success=L'adresse courriel est bien valide!
-confirmEmail.details.failure=Nous n'avons pas été en mesure de valider votre adresse courriel. Merci de cliquer sur le bouton « Valider le courriel » depuis la page comportant les renseignements sur votre compte.
+confirmEmail.details.failure=Nous n'avons pas été en mesure de valider votre adresse courriel. Merci de cliquer sur le bouton «\u00A0Valider le courriel\u00A0» depuis la page comportant les renseignements sur votre compte.
 confirmEmail.details.goToAccountPageButton=Aller à la page comportant les renseignements du compte
 confirmEmail.notVerified=Non validé
 confirmEmail.verified=Validé
@@ -307,7 +307,7 @@ confirmEmail.verified=Validé
 shib.btn.convertAccount=Convertir le compte
 shib.btn.createAccount=Créer le compte
 shib.askToConvert=Désirez-vous convertir votre compte Dataverse de façon à utiliser dorénavant vos informations de connexion institutionnelle afin de vous connecter?
-# Bundle file editors, please note that "shib.welcomeExistingUserMessage" is used in a unit test=
+# Bundle file editors, please note that "shib.welcomeExistingUserMessage" is used in a unit test
 shib.welcomeExistingUserMessage=Vos informations de connection institutionnelle pour {0} comprennent une adresse courriel déjà utilisée pour un compte Dataverse existant. En entrant ici-bas votre mot de passe Dataverse actuel, votre compte Dataverse pourra être converti de façon à ce que vous puissiez dorénavant utiliser votre compte institutionnel. Suite à cette conversion, vous n'aurez plus qu'à utiliser votre compte institutionnel pour pouvoir vous connecter. 
 # Bundle file editors, please note that "shib.welcomeExistingUserMessageDefaultInstitution" is used in a unit test=
 shib.welcomeExistingUserMessageDefaultInstitution=votre établissement
@@ -325,14 +325,14 @@ oauth2.welcomeExistingUserMessage=Votre compte institutionnel {0} correspond à u
 oauth2.welcomeExistingUserMessageDefaultInstitution=votre établissement
 oauth2.dataverseUsername=Nom d'utilisateur Dataverse
 oauth2.currentDataversePassword=Mot de passe Dataverse actuel
-oauth2.chooseUsername=Nom d'utilisateur: 
+oauth2.chooseUsername=Nom d'utilisateur\u00A0: 
 oauth2.passwordRejected=<strong>Erreur de validation</strong> - Nom d'utilisateur ou mot de passe incorrect.
 # oauth2.newAccount.title=Création de compte
 oauth2.newAccount.welcomeWithName=Bienvenue dans Dataverse, {0}
 oauth2.newAccount.welcomeNoName=Bienvenue dans Dataverse
 # oauth2.newAccount.email=Courriel
 # oauth2.newAccount.email.tip=Dataverse utilise ce courriel pour vous informer des problèmes liés à vos données.
-oauth2.newAccount.suggestedEmails=Adresses de courriel suggérées:
+oauth2.newAccount.suggestedEmails=Adresses de courriel suggérées\u00A0:
 oauth2.newAccount.username=Nom d'utilisateur
 oauth2.newAccount.username.tip=Ce nom d'utilisateur sera votre identifiant unique en tant qu'utilisateur Dataverse.
 oauth2.newAccount.explanation=Cette information est fournie par {0} et sera utilisée pour créer votre compte {1}. Pour vous connecter à nouveau, vous devrez utiliser l'option de connexion {0}.
@@ -356,7 +356,7 @@ oauth2.convertAccount.success=Votre compte Dataverse est maintenant associé à vo
 
 # oauth2/callback.xhtml
 oauth2.callback.page.title=Rappel OAuth
-oauth2.callback.message=<strong>Erreur d'authentification</strong> - Dataverse n'a pas pu authentifier votre connexion ORCID. Assurez-vous d'autoriser votre compte ORCID à se connecter à Dataverse. Pour plus de détails sur les informations demandées, voir la section <a href="{0}/{1}/user/account.html#orcid-log-in" title="ORCID Log In - Dataverse User Guide" target="_blank">authentification ORCID</a> du guide d'utilisation.
+oauth2.callback.message=<strong>Erreur d'authentification</strong> - Dataverse n'a pas pu authentifier votre connexion ORCID. Assurez-vous d'autoriser votre compte ORCID à se connecter à Dataverse. Pour plus de détails sur les informations demandées, voir la section <a href="{0}/{1}/user/account.html#orcid-log-in" title="Authentification ORCID - Guide d'utilisation de Dataverse" target="_blank">authentification ORCID</a> du guide d'utilisation.
 
 # tab on dataverseuser.xhtml
 apitoken.title=Jeton API
@@ -390,7 +390,7 @@ harvestclients.noClients.why.reason2=Les notices de métadonnées moissonnées sont
 harvestclients.noClients.how.header=Comment effectuer le moissonnage
 harvestclients.noClients.how.tip1=Afin de pouvoir moissonner des métadonnées, un <i>client de moissonnage</i> doit être défini et paramétré pour chacun des dépôts distants. Veuillez noter que pour définir un client, vous devrez sélectionner un dataverse local déjà existant, lequel hébergera les ensembles de données moissonnés.
 harvestclients.noClients.how.tip2=Les notices récoltées peuvent être synchronisées avec le dépôt d'origine à l'aide de mises à jour incrémentielles programmées, par exemple, quotidiennes ou hebdomadaires. Alternativement, les moissonnages peuvent être exécutés à la demande, à partir de cette page ou via l'API REST.
-harvestclients.noClients.getStarted=Pour commencer, cliquez sur le bouton « Ajouter un client » ci-dessus. Pour en savoir davantage sur le moissonnage, consultez la section <a href="{0}/{1}/user/index.html#index" title="Harvesting - Dataverse User Guide" target="_blank">moissonnage</a> du guide d'utilisation.
+harvestclients.noClients.getStarted=Pour commencer, cliquez sur le bouton «\u00A0Ajouter un client\u00A0» ci-dessus. Pour en savoir davantage sur le moissonnage, consultez la section <a href="{0}/{1}/user/index.html#index" title="Moissonnage - Guide d'utilisation de Dataverse" target="_blank">moissonnage</a> du guide d'utilisation.
 harvestclients.btn.add=Ajouter un client
 harvestclients.tab.header.name=Alias
 harvestclients.tab.header.url=Adresse URL
@@ -401,10 +401,10 @@ harvestclients.tab.header.action.btn.run=Lancer le moissonnage
 harvestclients.tab.header.action.btn.edit=Modifier
 harvestclients.tab.header.action.btn.delete=Supprimer
 harvestclients.tab.header.action.btn.delete.dialog.header=Supprimer le client de moissonnage
-harvestclients.tab.header.action.btn.delete.dialog.warning=Voulez-vous vraiment supprimer le client de moissonnage "{0}"? La suppression du client supprimera tous les ensembles de données récoltés à partir de ce serveur distant.
+harvestclients.tab.header.action.btn.delete.dialog.warning=Voulez-vous vraiment supprimer le client de moissonnage «\u00A0{0}\u00A0»? La suppression du client supprimera tous les ensembles de données récoltés à partir de ce serveur distant.
 harvestclients.tab.header.action.btn.delete.dialog.tip=Veuillez noter que cette opération peut prendre un certain temps à effectuer en fonction du nombre d'ensembles de données récoltés.
 harvestclients.tab.header.action.delete.infomessage=La suppression du client de moissonnage est lancée. Notez que cela peut prendre un certain temps en fonction de la quantité de contenu récolté.
-harvestclients.actions.runharvest.success=Lancement réussi d'un moissonnage asynchrone pour le client "{0}". Veuillez recharger la page pour vérifier les résultats de la récolte.
+harvestclients.actions.runharvest.success=Lancement réussi d'un moissonnage asynchrone pour le client «\u00A0{0}\u00A0». Veuillez recharger la page pour vérifier les résultats de la récolte.
 harvestclients.newClientDialog.step1=Étape 1 de 4 - Renseignements au sujet du client
 harvestclients.newClientDialog.title.new=Définir un client de moissonnage
 harvestclients.newClientDialog.help=Configurer un client pour moissonner le contenu d'un serveur distant
@@ -419,8 +419,8 @@ harvestclients.newClientDialog.type.OAI=OAI
 harvestclients.newClientDialog.type.Nesstar=Nesstar
 harvestclients.newClientDialog.url=URL du serveur
 harvestclients.newClientDialog.url.tip=URL d'une source moisssonnée.
-harvestclients.newClientDialog.url.watermark=URL du serveur moissonné distant, http://...
-harvestclients.newClientDialog.url.helptext.notvalidated=URL d'une source moisssonnée. Une fois le bouton « Suivant » cliqué, nous tenterons d'établir une connexion avec le serveur afin de vérifier qu'il fonctionne bien et obtenir des informations supplémentaires sur ses caractéristiques.
+harvestclients.newClientDialog.url.watermark=URL du serveur moissonné distant, http://\u2026
+harvestclients.newClientDialog.url.helptext.notvalidated=URL d'une source moisssonnée. Une fois le bouton «\u00A0Suivant\u00A0» cliqué, nous tenterons d'établir une connexion avec le serveur afin de vérifier qu'il fonctionne bien et obtenir des informations supplémentaires sur ses caractéristiques.
 harvestclients.newClientDialog.url.required=Une adresse valide de serveur à moissonner est requise.
 harvestclients.newClientDialog.url.invalid=URL non valide. Impossible d'établir une connexion et recevoir une réponse valide du serveur.
 harvestclients.newClientDialog.url.noresponse=Impossible d'établir la connexion avec le serveur.
@@ -435,7 +435,7 @@ harvestclients.newClientDialog.step2=Étape 2 de 4 - Format
 harvestclients.newClientDialog.oaiSets=Ensemble OAI
 harvestclients.newClientDialog.oaiSets.tip=Ensembles moissonnables offerts par ce serveur OAI.
 harvestclients.newClientDialog.oaiSets.noset=Aucun
-harvestclients.newClientDialog.oaiSets.helptext=En sélectionnant « Aucun » le moissonnage se fera sur l'ensemble par défaut défini par le serveur. Fréquemment il s'agit de l'entièreté du contenu de tous les sous-ensembles.
+harvestclients.newClientDialog.oaiSets.helptext=En sélectionnant «\u00A0Aucun\u00A0» le moissonnage se fera sur l'ensemble par défaut défini par le serveur. Fréquemment il s'agit de l'entièreté du contenu de tous les sous-ensembles.
 harvestclients.newClientDialog.oaiSets.helptext.noset=Ce serveur OAI ne prend pas en charge les ensembles sélectionnés. L'ensemble du contenu proposé par le serveur sera moissonné.
 harvestclients.newClientDialog.oaiMetadataFormat=Format des métadonnées
 harvestclients.newClientDialog.oaiMetadataFormat.tip=Formats de métadonnées offerts par le serveur distant.
@@ -453,7 +453,7 @@ harvestclients.newClientDialog.schedule.time.am=a.m.
 harvestclients.newClientDialog.schedule.time.pm=p.m.
 harvestclients.newClientDialog.schedule.time.helptext=L'horaire programmé se réfère à votre heure locale.
 harvestclients.newClientDialog.btn.create=Créer un client
-harvestclients.newClientDialog.success=Le client de moissonnage "{0}" a bien été créé.
+harvestclients.newClientDialog.success=Le client de moissonnage «\u00A0{0}\u00A0» a bien été créé.
 harvestclients.newClientDialog.step4=Étape 4 de 4 - Affichage
 harvestclients.newClientDialog.harvestingStyle=Type de dépôt
 harvestclients.newClientDialog.harvestingStyle.tip=Type du dépôt distant.
@@ -482,8 +482,8 @@ harvestserver.noSets.why.reason1=Le moissonnage consiste à échanger des métadonn
 harvestserver.noSets.why.reason2=Seuls les ensembles de données publiés et non restreints de votre Dataverse peuvent être moissonnés. Les clients distants maintiennent normalement leurs enregistrements synchronisés grâce à des mises à jour incrémentielles programmées, quotidiennes ou hebdomadaires, réduisant ainsi la charge sur votre serveur. Notez que seules les métadonnées sont moissonnées. Les moissonneurs distants ne tentent généralement pas de télécharger eux-mêmes les fichiers de données.
 harvestserver.noSets.how.header=Comment activer un serveur de moissonnage?
 harvestserver.noSets.how.tip1=Le serveur de moissonnage peut être activé ou désactivé à partir de cette page. 
-harvestserver.noSets.how.tip2=Une fois le service activé, vous pouvez définir des collections d'ensembles de données locaux qui seront disponibles pour les moissonneurs distants sous <i>Ensembles OAI</i>. Les ensembles sont définis par des requêtes de recherche (par exemple, authorName:king; ou parentId:1234 - pour sélectionner tous les ensembles de données appartenant au dataverse spécifié; ou dsPersistentId: "doi:1234/" pour sélectionner tous les ensembles de données avec l'identifiant perenne spécifié). Consultez la section sur l'API de recherche du guide d'utilisation de Dataverse pour plus d'informations sur les requêtes de recherche.  
-harvestserver.noSets.getStarted=Pour commencer, activez le serveur OAI et cliquez sur le bouton « Ajouter un ensemble (set) ». Pour en savoir plus sur le moissonnage, consultez la section  <a href="{0}/{1}/user/index.html#index" title="Harvesting - Dataverse User Guide" target="_blank">moissonnage</a> du guide d'utilisation.
+harvestserver.noSets.how.tip2=Une fois le service activé, vous pouvez définir des collections d'ensembles de données locaux qui seront disponibles pour les moissonneurs distants sous <i>Ensembles OAI</i>. Les ensembles sont définis par des requêtes de recherche (par exemple, authorName:king; ou parentId:1234 - pour sélectionner tous les ensembles de données appartenant au dataverse spécifié; ou dsPersistentId:"doi:1234/" pour sélectionner tous les ensembles de données avec l'identifiant perenne spécifié). Consultez la section sur l'API de recherche du guide d'utilisation de Dataverse pour plus d'informations sur les requêtes de recherche.  
+harvestserver.noSets.getStarted=Pour commencer, activez le serveur OAI et cliquez sur le bouton «\u00A0Ajouter un ensemble (set)\u00A0». Pour en savoir plus sur le moissonnage, consultez la section  <a href="{0}/{1}/user/index.html#index" title="Moissonnage - Guide d'utilisation de Dataverse" target="_blank">moissonnage</a> du guide d'utilisation.
 harvestserver.btn.add=Ajouter un ensemble (set)
 harvestserver.tab.header.spec=setSpec OAI (identifiant OAI de l'ensemble)
 harvestserver.tab.header.description=Description
@@ -493,11 +493,11 @@ harvestserver.tab.col.stats.empty=Aucun enregistrement (ensemble vide)
 harvestserver.tab.col.stats.results={0} {0, choice, 0#Ensembles de données|1#Ensemble de données|2#Ensembles de données} ({1} {1, choice, 0#enregistrements|1#enregistrement|2#enregistrements} exporté(s), {2} marqué(s) comme supprimé(s))
 harvestserver.tab.header.action=Opérations
 harvestserver.tab.header.action.btn.export=Lancer l'exportation
-harvestserver.actions.runreexport.success=La tâche asynchrone de réexportation de l'ensemble OAI "{0}" a bien été lancée (veuillez recharger la page pour suivre la progression de l'exportation).
+harvestserver.actions.runreexport.success=La tâche asynchrone de réexportation de l'ensemble OAI «\u00A0{0}\u00A0» a bien été lancée (veuillez recharger la page pour suivre la progression de l'exportation).
 harvestserver.tab.header.action.btn.edit=Modifier
 harvestserver.tab.header.action.btn.delete=Supprimer
 harvestserver.tab.header.action.btn.delete.dialog.header=Supprimer l'ensemble à moissonner
-harvestserver.tab.header.action.btn.delete.dialog.tip=Voulez-vous vraiment supprimer l'ensemble OAI "{0}"? Vous ne pouvez pas annuler une suppression!
+harvestserver.tab.header.action.btn.delete.dialog.tip=Voulez-vous vraiment supprimer l'ensemble OAI «\u00A0{0}\u00A0»? Vous ne pouvez pas annuler une suppression!
 harvestserver.tab.header.action.delete.infomessage=L'ensemble à moissonner est supprimé. (Ceci peut prendre un certain temps)
 harvestserver.newSetDialog.title.new=Définir un ensemble à moissonner
 harvestserver.newSetDialog.help=Définir une collection d'ensembles de données locaux qui seront disponibles pour le moissonnage par les clients distants.
@@ -508,20 +508,20 @@ harvestserver.editSetDialog.setspec.helptext=Le nom ne peut pas être modifié une
 harvestserver.newSetDialog.setspec.required=Le nom (setSpec OAI) ne peut être vide!
 harvestserver.newSetDialog.setspec.invalid=Le nom (setSpec OAI) ne peut contenir que des lettres, des chiffres, des traits de soulignement (_) et des tirets (-).
 harvestserver.newSetDialog.setspec.alreadyused=Ce nom d'ensemble (setSpec OAI) est déjà utilisé.
-harvestserver.newSetDialog.setspec.sizelimit=This set name (OAI setSpec) may be no longer than 30 characters.
-harvestserver.newSetDialog.setspec.superUser.required=Only superusers may create OAI sets.
+harvestserver.newSetDialog.setspec.sizelimit=Ce nom d'ensemble (OAI setSpec) ne peut compter plus de 30 caractères.
+harvestserver.newSetDialog.setspec.superUser.required=Seuls les super-utilisateurs peuvent créer des ensembles OAI.
 
 harvestserver.newSetDialog.setdescription=Description
 harvestserver.newSetDialog.setdescription.tip=Fournir une brève description de cet ensemble OAI.
 harvestserver.newSetDialog.setdescription.required=La description de l'ensemble ne peut être vide!
 harvestserver.newSetDialog.setquery=Requête de recherche
 harvestserver.newSetDialog.setquery.tip=Requête de recherche qui définit le contenu de l'ensemble de données.
-harvestserver.newSetDialog.setquery.helptext=Exemple de requête: authorName:king
+harvestserver.newSetDialog.setquery.helptext=Exemple de requête\u00A0: authorName:king
 harvestserver.newSetDialog.setquery.required=La requête de recherche ne peut être vide!
 harvestserver.newSetDialog.setquery.results=La requête de recherche a retourné {0} ensemble(s) de données!
-harvestserver.newSetDialog.setquery.empty=AVERTISSEMENT: la requête de recherche n'a retourné aucun résultat!
+harvestserver.newSetDialog.setquery.empty=AVERTISSEMENT\u00A0: la requête de recherche n'a retourné aucun résultat!
 harvestserver.newSetDialog.btn.create=Créer l'ensemble
-harvestserver.newSetDialog.success=L'ensemble de données "{0}" a bien été créé.
+harvestserver.newSetDialog.success=L'ensemble de données «\u00A0{0}\u00A0» a bien été créé.
 harvestserver.viewEditDialog.title=Modifier l'ensemble moissonné.
 harvestserver.viewEditDialog.btn.save=Sauvegarder les modifications
 
@@ -531,7 +531,7 @@ dashboard.card.users.header=Tableau de bord - Liste des utilisateurs
 dashboard.card.users.super=Super-utilisateurs
 dashboard.card.users.manage=Gérer les utilisateurs
 dashboard.card.users.message=Lister et gérer les utilisateurs.
-dashboard.list_users.searchTerm.watermark=Rechercher ces utilisateurs...
+dashboard.list_users.searchTerm.watermark=Rechercher ces utilisateurs\u2026
 dashboard.list_users.tbl_header.userId=Identifiant
 dashboard.list_users.tbl_header.userIdentifier=Nom d'utilisateur
 dashboard.list_users.tbl_header.name=Nom 
@@ -560,54 +560,54 @@ dashboard.list_users.api.auth.invalid_apikey=La clé API n'est pas valide.
 dashboard.list_users.api.auth.not_superuser=Action Interdite. Vous devez être un super-utilisateur.
 
 #MailServiceBean.java
-notification.email.create.dataverse.subject={0}: Votre dataverse a été créé.
-notification.email.create.dataset.subject={0}: Votre ensemble de données a été créé.
-notification.email.request.file.access.subject={0}: Vous avez présenté une demande d''accès à un fichier en accès réservé.
-notification.email.grant.file.access.subject={0}: L''accès à un fichier réservé vous a été accordé.
-notification.email.rejected.file.access.subject={0}: Votre demande d''accès à un fichier en accès réservé a été refusée.
-notification.email.update.maplayer={0}: Une couche WorldMap a été ajoutée à l''ensemble de données.
+notification.email.create.dataverse.subject={0}\u00A0: Votre dataverse a été créé.
+notification.email.create.dataset.subject={0}\u00A0: Votre ensemble de données a été créé.
+notification.email.request.file.access.subject={0}\u00A0: Vous avez présenté une demande d''accès à un fichier en accès réservé.
+notification.email.grant.file.access.subject={0}\u00A0: L''accès à un fichier réservé vous a été accordé.
+notification.email.rejected.file.access.subject={0}\u00A0: Votre demande d''accès à un fichier en accès réservé a été refusée.
+notification.email.update.maplayer={0}\u00A0: Une couche WorldMap a été ajoutée à l''ensemble de données.
 notification.email.maplayer.deletefailed.subject={0}: Impossible de supprimer la couche WorldMap.
-notification.email.maplayer.deletefailed.text=Impossible de supprimer la couche WorldMap associée au fichier à accès restreint {0}, ainsi que toutes les données connexes qui peuvent encore être publiquement disponibles sur le site de WorldMap. Essayez de nouveau, ou contactez le soutien WorldMap et/ou Dataverse. (Ensemble de données: {1})
-notification.email.submit.dataset.subject={0}: Votre ensemble de données a été soumis à la révision.
-notification.email.publish.dataset.subject={0}: Votre ensemble de données a été publié.
-notification.email.returned.dataset.subject={0}: Votre ensemble de données a été retourné.
-notification.email.create.account.subject={0}: Votre compte a été créé.
-notification.email.assign.role.subject={0}:  Un rôle vous a été attribué
-notification.email.revoke.role.subject={0}: Votre rôle a été révoqué
-notification.email.verifyEmail.subject={0}: Valider votre adresse courriel
+notification.email.maplayer.deletefailed.text=Impossible de supprimer la couche WorldMap associée au fichier à accès restreint {0}, ainsi que toutes les données connexes qui peuvent encore être publiquement disponibles sur le site de WorldMap. Essayez de nouveau, ou contactez le soutien WorldMap et/ou Dataverse. (Ensemble de données\u00A0: {1})
+notification.email.submit.dataset.subject={0}\u00A0: Votre ensemble de données a été soumis à la révision.
+notification.email.publish.dataset.subject={0}\u00A0: Votre ensemble de données a été publié.
+notification.email.returned.dataset.subject={0}\u00A0: Votre ensemble de données a été retourné.
+notification.email.create.account.subject={0}\u00A0: Votre compte a été créé.
+notification.email.assign.role.subject={0}\u00A0:  Un rôle vous a été attribué
+notification.email.revoke.role.subject={0}\u00A0: Votre rôle a été révoqué
+notification.email.verifyEmail.subject={0}\u00A0: Valider votre adresse courriel
 notification.email.greeting=Bonjour, \n
 # Bundle file editors, please note that "notification.email.welcome" is used in a unit test
 notification.email.welcome=Bienvenue dans {0}! Commencez dès maintenant en ajoutant ou encore en recherchant des données. Des questions? Consultez le guide d''utilisation ici {1}/{2}/user/ ou contactez le service de soutien {3} de {4} pour de l''aide.
 notification.email.welcomeConfirmEmailAddOn=\n\nVeuillez vérifier votre adresse courriel à {0}. Notez que le lien de validation expirera après {1}. Envoyez de nouveau un courriel de validation en vous rendant à la page de votre compte.
-notification.email.requestFileAccess=Accès au fichier demandé pour l''ensemble de données: {0}. Gérer les autorisations à {1}.
-notification.email.grantFileAccess=Accès accordé aux fichiers de l''ensemble de données: {0} (voir {1}).
-notification.email.rejectFileAccess=Votre demande d''accès a été rejetée pour les fichiers demandés de l''ensemble de données: {0} (voir {1}). Si vous avez des questions sur la raison pour laquelle votre demande a été rejetée, vous pouvez contacter le propriétaire de l''ensemble de données à l''aide du lien "Contact" dans le coin supérieur droit de la page de l''ensemble de données.
+notification.email.requestFileAccess=Accès au fichier demandé pour l''ensemble de données\u00A0: {0}. Gérer les autorisations à {1}.
+notification.email.grantFileAccess=Accès accordé aux fichiers de l''ensemble de données\u00A0: {0} (voir {1}).
+notification.email.rejectFileAccess=Votre demande d''accès a été rejetée pour les fichiers demandés de l''ensemble de données\u00A0: {0} (voir {1}). Si vous avez des questions sur la raison pour laquelle votre demande a été rejetée, vous pouvez contacter le propriétaire de l''ensemble de données à l''aide du lien «\u00A0Personne-ressource\u00A0» dans le coin supérieur droit de la page de l''ensemble de données.
 # Bundle file editors, please note that "notification.email.createDataverse" is used in a unit test=
-notification.email.createDataverse=Votre nouveau dataverse intitulé {0} (voir {1}) a été créé dans {2} (voir {3}). Pour en savoir plus sur ce que vous pouvez faire avec votre dataverse, consultez le Guide de l''utilisateur Dataverse à l''adresse suivante: {4}/{5}/user/dataverse-management.html .
+notification.email.createDataverse=Votre nouveau dataverse intitulé {0} (voir {1}) a été créé dans {2} (voir {3}). Pour en savoir plus sur ce que vous pouvez faire avec votre dataverse, consultez le Guide de l''utilisateur Dataverse à l''adresse suivante\u00A0: {4}/{5}/user/dataverse-management.html .
 # Bundle file editors, please note that "notification.email.createDataset" is used in a unit test=
-notification.email.createDataset=Votre nouvel ensemble de données intitulé {0} (voir {1}) a été créé dans {2} (voir {3}). Pour en savoir plus sur ce que vous pouvez faire avec un ensemble de données, consultez le Guide Dataverse sur la gestion d''un ensemble de données à l''adresse suivante: {4}/{5}/user/dataset-management.html .
+notification.email.createDataset=Votre nouvel ensemble de données intitulé {0} (voir {1}) a été créé dans {2} (voir {3}). Pour en savoir plus sur ce que vous pouvez faire avec un ensemble de données, consultez le Guide Dataverse sur la gestion d''un ensemble de données à l''adresse suivante\u00A0: {4}/{5}/user/dataset-management.html .
 notification.email.wasSubmittedForReview={0} (voir {1}) a été soumis aux fins d''examen en vue de sa publication dans {2}  (voir {3}). N''oubliez pas de le publier ou de le renvoyer au collaborateur\!
 notification.email.wasReturnedByReviewer={0} (voir {1}) a été retourné par l''intendant des données de {2} (voir {3}).
 notification.email.wasPublished={0} (voir {1}) a été publié dans {2} (voir {3}).
 notification.email.worldMap.added=Les données d''une couche WorldMap ont été ajoutées à {0} (voir {1}).
-notification.email.closing=\n\nYou may contact us for support at {0}.\n\nThank you,\n{1}
-notification.email.assignRole=Vous êtes maintenant {0} pour: {1} "{2}" (voir {3}).
-notification.email.revokeRole=Un de vos rôles pour {0} "{1}" a été révoqué (voir {2}).
+notification.email.closing=\n\nVous pouvez nous contacter pour du soutien à {0}.\n\nMerci,\n{1}
+notification.email.assignRole=Vous êtes maintenant {0} pour\u00A0: {1} «\u00A0{2}\u00A0» (voir {3}).
+notification.email.revokeRole=Un de vos rôles pour {0} «\u00A0{1}\u00A0» a été révoqué (voir {2}).
 notification.email.changeEmail=Bonjour, {0}.{1}\n\nVeuillez nous contacter si vous n''aviez pas l''intention de faire cette modification ou si vous avez besoin d''aide.
 hours=heures
-hour=heures
+hour=heure
 minutes=minutes
 minute=minute
-notification.email.checksumfail.subject={0}: votre validation de somme de contrôle a échouée
+notification.email.checksumfail.subject={0}\u00A0: votre validation de somme de contrôle a échouée
 notification.email.import.filesystem.subject=L''ensemble de données {0} a bien été téléchargé et vérifié
-notification.email.import.checksum.subject={0}: Votre tâche de somme de contrôle de fichier est complétée
-contact.delegation={0} on behalf of {1}
+notification.email.import.checksum.subject={0}\u00A0: Votre tâche de somme de contrôle de fichier est complétée
+contact.delegation={0} au nom de {1}
 
-# passwordreset.xhtml
+# passwordreset.xhtml=
 pageTitle.passwdReset.pre=Réinitialisation du mot de passe du compte
-passwdReset.token=Jeton:
-passwdReset.userLookedUp=Utilisateur recherché:
-passwdReset.emailSubmitted=Courriel soumis:
+passwdReset.token=Jeton\u00A0:
+passwdReset.userLookedUp=Utilisateur recherché\u00A0:
+passwdReset.emailSubmitted=Courriel soumis\u00A0:
 passwdReset.details={0} Réinitialisation du mot de passe{1} - Pour débuter le processus de réinitialisation du mot de passe, veuillez indiquer votre adresse courriel. 
 passwdReset.submitRequest=Soumettre la demande de mot de passe
 passwdReset.successSubmit.tip=Si cette adresse courriel est associée à un compte, un courriel sera envoyé avec des instructions supplémentaires à {0}.
@@ -622,13 +622,13 @@ passwdReset.resetBtn=Réinitialiser le mot de passe
 
 # dataverse.xhtml=
 dataverse.title=Le projet, le département, l'université ou le chercheur visé par les données contenues dans le dataverse.
-dataverse.enterName=Entrer le nom...
+dataverse.enterName=Entrer le nom\u2026
 dataverse.host.title=Le dataverse qui contient ces données.
 dataverse.identifier.title=Nom abrégé utilisé pour l'adresse URL de ce dataverse.
 dataverse.affiliation.title=L'organisation avec laquelle ce dataverse est affilié.
 dataverse.category=Catégorie
 dataverse.category.title=Le type correspondant le mieux à ce dataverse.
-dataverse.type.selectTab.top=Sélectionner...
+dataverse.type.selectTab.top=Sélectionner\u2026
 dataverse.type.selectTab.researchers=Chercheur
 dataverse.type.selectTab.researchProjects=Projet de recherche
 dataverse.type.selectTab.journals=Revue
@@ -651,7 +651,7 @@ dataverse.metadataElements.from.tip=Utiliser les champs de métadonnées de {0}
 dataverse.resetModifications=Réinitialiser les modifications
 dataverse.resetModifications.text=Êtes-vous sûr(e) de vouloir réinitialiser les champs de métadonnées sélectionnés? Si vous les réinitialisez, toute personnalisation effectuée (information cachée, obligatoire, facultative) sera annulée.
 dataverse.field.required=(Obligatoire)
-dataverse.field.example1=(Exemples:
+dataverse.field.example1=(Exemples\u00A0:
 dataverse.field.example2=)
 dataverse.field.set.tip=[+] Voir les champs + les définir comme champs cachés, obligatoires ou facultatifs
 dataverse.field.set.view=[+] Voir les champs
@@ -683,7 +683,7 @@ dataset.link.save=Enregistrer l'ensemble de données lié
 dataverse.link.dataverse.choose=Déterminez avec lequel de vos dataverses vous souhaitez lier ce dataverse.
 dataverse.link.dataset.choose=Déterminez avec lequel de vos dataverses vous souhaitez lier cet ensemble de données.
 dataverse.link.no.choice=Vous avez un dataverse dans lequel vous pouvez ajouter des ensembles de données et des dataverses liés. 
-dataverse.link.no.linkable=Vous devez posséder votre propre dataverse pour pouvoir lier un dataverse ou un ensemble de données. Cliquer sur le bouton «Ajouter des données» à la page d'accueil pour commencer.
+dataverse.link.no.linkable=Vous devez posséder votre propre dataverse pour pouvoir lier un dataverse ou un ensemble de données. Cliquer sur le bouton «\u00A0Ajouter des données\u00A0» à la page d'accueil pour commencer.
 dataverse.link.no.linkable.remaining=Vous avez déjà lié tous vos dataverses admissibles.
 dataverse.savedsearch.link=Recherche de liens
 dataverse.savedsearch.searchquery=Recherche
@@ -691,7 +691,7 @@ dataverse.savedsearch.filterQueries=Facettes
 dataverse.savedsearch.save=Enregistrer la recherche de liens
 dataverse.savedsearch.dataverse.choose=Déterminez avec lequel de vos dataverses vous souhaitez lier cette recherche.
 dataverse.savedsearch.no.choice=Vous avez un dataverse pour lequel vous pouvez ajouter une recherche sauvegardée.
-# Bundle file editors, please note that "dataverse.savedsearch.save.success" is used in a unit test=
+# Bundle file editors, please note that "dataverse.savedsearch.save.success" is used in a unit test
 dataverse.saved.search.success=La recherche sauvegardée est maintenant liée à {0}.
 dataverse.saved.search.failure=La recherche sauvegardée n'a pas pu être liée.
 dataverse.linked.success={0} est maintenant lié à {1}.
@@ -711,17 +711,17 @@ dataverse.delete.tip=Êtes-vous sûr(e) de vouloir supprimer votre dataverse? Vous
 dataverse.delete=Supprimer le dataverse
 dataverse.delete.success=Votre dataverse a été supprimé.
 dataverse.delete.failure=Ce dataverse n'a pas pu être supprimé. 
-# Bundle file editors, please note that "dataverse.create.success" is used in a unit test because it's so fancy with two parameters=
-dataverse.create.success=Vous avez bien réussi à créer votre dataverse! Pour en savoir davantage sur ce que vous pouvez faire avec votre dataverse, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Dataverse Management - Dataverse User Guide" target="_blank">guide d'utilisation</a>.
+# Bundle file editors, please note that "dataverse.create.success" is used in a unit test because it's so fancy with two parameters
+dataverse.create.success=Vous avez bien réussi à créer votre dataverse! Pour en savoir davantage sur ce que vous pouvez faire avec votre dataverse, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Administration de Dataverse - Guide d'utilisation de Dataverse" target="_blank">guide d'utilisation</a>.
 dataverse.create.failure=Ce dataverse n'a pas pu être créé. 
 dataverse.create.authenticatedUsersOnly=Seuls les utilisateurs authentifiés peuvent créer des dataverses.
 dataverse.update.success=Vous avez bien mis à jour votre dataverse!
 dataverse.update.failure=Ce dataverse n'a pas pu être mis à jour.
-dataverse.selected=Selected
+dataverse.selected=Sélectionné
 
-# rolesAndPermissionsFragment.xhtml=
+# rolesAndPermissionsFragment.xhtml
 
-# advanced.xhtml=
+# advanced.xhtml
 advanced.search.header.dataverses=Dataverses
 advanced.search.dataverses.name.tip=Le projet, le département, l'université ou le professeur visé par les données contenues dans ce dataverse.
 advanced.search.dataverses.affiliation.tip=L'organisation avec laquelle ce dataverse est affilié.
@@ -731,44 +731,44 @@ advanced.search.header.datasets=Ensembles de données
 advanced.search.header.files=Fichiers
 advanced.search.files.name.tip=Le nom donné au fichier.
 advanced.search.files.description.tip=Un résumé décrivant le fichier et ses variables.
-advanced.search.files.persistentId.tip=The persistent identifier for the file.
-advanced.search.files.persistentId=Data File Persistent ID
-advanced.search.files.persistentId.tip=The unique persistent identifier for a data file, which can be a Handle or DOI in Dataverse.
+advanced.search.files.persistentId.tip=L'identifiant permanent du fichier.
+advanced.search.files.persistentId=Identifiant permanent du fichier de données
+advanced.search.files.persistentId.tip=L'identifiant unique permanent pour un fichier de données, lequel peut être dans Dataverse un Handle ou un DOI.
 advanced.search.files.fileType=Type de fichier
-advanced.search.files.fileType.tip=L'extension d'un fichier, p.ex. CSV, zip, Stata, R, PDF, JPEG, etc.
+advanced.search.files.fileType.tip=L'extension d'un fichier, p.\u00A0ex. CSV, zip, Stata, R, PDF, JPEG, etc.
 advanced.search.files.variableName=Nom de la variable
 advanced.search.files.variableName.tip=Le titre de la colonne pour cette variable dans la table de données.
 advanced.search.files.variableLabel=Libellé de variable
 advanced.search.files.variableLabel.tip=Une courte description de la variable.
-advanced.search.datasets.persistentId.tip=The persistent identifier for the dataset.
-advanced.search.datasets.persistentId=Dataset Persistent ID
-advanced.search.datasets.persistentId.tip=The unique persistent identifier for a dataset, which can be a Handle or DOI in Dataverse.
+advanced.search.datasets.persistentId.tip=L'identifiant permanent de l'ensemble de données.
+advanced.search.datasets.persistentId=Identifiant permanent de l'ensemble de données
+advanced.search.datasets.persistentId.tip=L'identifiant unique permanent pour un ensemble de données, lequel peut être dans Dataverse un Handle ou un DOI.
 
 # search-include-fragment.xhtml
 dataverse.search.advancedSearch=Recherche avancée
-dataverse.search.input.watermark=Chercher dans ce dataverse...
-account.search.input.watermark=Chercher ces données...
+dataverse.search.input.watermark=Chercher dans ce dataverse\u2026
+account.search.input.watermark=Chercher ces données\u2026
 dataverse.search.btn.find=Trouver
 dataverse.results.btn.addData=Ajouter des données
 dataverse.results.btn.addData.newDataverse=Nouveau dataverse
 dataverse.results.btn.addData.newDataset=Nouvel ensemble de données
 dataverse.results.dialog.addDataGuest.header=Ajouter des données
 dataverse.results.dialog.addDataGuest.msg=Vous devez <a href="/loginpage.xhtml{0}" title="vous connecter à votre compte Dataverse">vous authentifier</a> pour créer un dataverse ou ajouter un ensemble de données.
-dataverse.results.dialog.addDataGuest.msg.signup=You need to <a href="{0}" title="Sign Up for a Dataverse Account">Sign Up</a> or <a href="/loginpage.xhtml{0}" title="Log into your Dataverse Account">Log In</a> to create a dataverse or add a dataset.
+dataverse.results.dialog.addDataGuest.msg.signup=Vous devez <a href="{0}" title="Ouvrir un compte Dataverse">ouvrir un compte</a> ou <a href="/loginpage.xhtml{0}" title="vous connecter à votre compte Dataverse">vous connecter</a> pour créer un dataverse ou ajouter un ensemble de données.
 dataverse.results.types.dataverses=Dataverses
 dataverse.results.types.datasets=Ensembles de données
 dataverse.results.types.files=Fichiers
 # Bundle file editors, please note that "dataverse.results.empty.zero" is used in a unit test
-dataverse.results.empty.zero=Aucun dataverse, ensemble de données ou fichier ne correspond à votre recherche. Veuillez effectuer une nouvelle recherche en utilisant d'autres termes ou des termes plus généraux. Vous pouvez également consulter le <a href="{0}/{1}/user/find-use-data.html" title="Finding &amp; Using Data - Dataverse User Guide" target="_blank">guide de recherche</a> pour des astuces.
+dataverse.results.empty.zero=Aucun dataverse, ensemble de données ou fichier ne correspond à votre recherche. Veuillez effectuer une nouvelle recherche en utilisant d'autres termes ou des termes plus généraux. Vous pouvez également consulter le <a href="{0}/{1}/user/find-use-data.html" title="Trouver et utiliser des données - Guide d'utilisation de Dataverse" target="_blank">guide de recherche</a> pour des astuces.
 # Bundle file editors, please note that "dataverse.results.empty.hidden" is used in a unit test
-dataverse.results.empty.hidden=Il n'y a pas de résultats répondants à vos critères de recherche. Vous pouvez consulter le <a href="{0}/{1}/user/find-use-data.html" Finding &amp; Using Data - Dataverse User Guide" target="_blank">guide de recherche</a> pour des conseils.
-dataverse.results.empty.browse.guest.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Veuillez <a href="/loginpage.xhtml{0}" title="vous connecter à votre compte Dataverse">vous authentifier</a> pour voir si vous pouvez y ajouter du contenu. 
-dataverse.results.empty.browse.guest.hidden=Ce dataverse ne contient aucun dataverse. Veuillez <a href="/loginpage.xhtml{0}" title="vous connecter à votre compte Dataverse">vous authentifier</a> pour voir si vous pouvez y ajouter du contenu. 
-dataverse.results.empty.browse.loggedin.noperms.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Vous pouvez utiliser le bouton «Envoyer un courriel au contact du dataverse» ci-dessus pour toute question sur ce dataverse ou pour effectuer une demande d'accès à ce dataverse.
+dataverse.results.empty.hidden=Il n'y a pas de résultats répondants à vos critères de recherche. Vous pouvez consulter le <a href="{0}/{1}/user/find-use-data.html" title="Trouver et utiliser des données - Guide d'utilisation de Dataverse" target="_blank">guide de recherche</a> pour des conseils.
+dataverse.results.empty.browse.guest.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Veuillez <a href="/loginpage.xhtml{0}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour voir si vous pouvez y ajouter du contenu. 
+dataverse.results.empty.browse.guest.hidden=Ce dataverse ne contient aucun dataverse. Veuillez <a href="/loginpage.xhtml{0}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour voir si vous pouvez y ajouter du contenu. 
+dataverse.results.empty.browse.loggedin.noperms.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Vous pouvez utiliser le bouton «\u00A0Envoyer un courriel au contact du dataverse\u00A0» ci-dessus pour toute question sur ce dataverse ou pour effectuer une demande d'accès à ce dataverse.
 dataverse.results.empty.browse.loggedin.noperms.hidden=Il n'y a aucun dataverse dans ce dataverse.
-dataverse.results.empty.browse.loggedin.perms.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Vous pouvez en ajouter à l'aide du bouton «Ajouter des données» qui se trouve sur cette page.
-account.results.empty.browse.loggedin.perms.zero=Il n'y a aucun dataverse, ensemble de données ou fichier associé à votre compte. Vous pouvez ajouter un dataverse ou un ensemble de données en cliquant sur le bouton «Ajouter des données» ci-dessus. Pour en savoir plus sur l'ajout de données, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Dataverse Management - Dataverse User Guide" target="_blank">guide d'utilisation</a>
-dataverse.results.empty.browse.loggedin.perms.hidden=Il n'y a aucun dataverse dans ce dataverse. Vous pouvez en ajouter à l'aide du bouton «Ajouter des données» qui se trouve sur cette page.
+dataverse.results.empty.browse.loggedin.perms.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Vous pouvez en ajouter à l'aide du bouton «\u00A0Ajouter des données\u00A0» qui se trouve sur cette page.
+account.results.empty.browse.loggedin.perms.zero=Il n'y a aucun dataverse, ensemble de données ou fichier associé à votre compte. Vous pouvez ajouter un dataverse ou un ensemble de données en cliquant sur le bouton «\u00A0Ajouter des données\u00A0» ci-dessus. Pour en savoir plus sur l'ajout de données, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Administration de Dataverse - Guide d'utilisation de Dataverse" target="_blank">guide d'utilisation</a>
+dataverse.results.empty.browse.loggedin.perms.hidden=Il n'y a aucun dataverse dans ce dataverse. Vous pouvez en ajouter à l'aide du bouton «\u00A0Ajouter des données\u00A0» qui se trouve sur cette page.
 dataverse.results.empty.link.technicalDetails=Plus de détails techniques
 dataverse.search.facet.error=Une erreur s'est produite avec vos paramètres de recherche. Veuillez <a href="/dataverse/{0}"> effacer votre recherche </a> et essayer de nouveau.
 dataverse.results.count.toofresults={0} à {1} de {2} {2, choice, 0#résultats|1#résultat|2#résultats}
@@ -779,7 +779,7 @@ dataverse.results.btn.sort.option.nameZA=Nom (Z-A)
 dataverse.results.btn.sort.option.newest=Plus récent
 dataverse.results.btn.sort.option.oldest=Plus ancien
 dataverse.results.btn.sort.option.relevance=Pertinence
-dataverse.results.cards.foundInMetadata=Trouvé(s) dans les champs de métadonnées:
+dataverse.results.cards.foundInMetadata=Trouvé(s) dans les champs de métadonnées\u00A0:
 dataverse.results.cards.files.tabularData=Données tabulaires
 dataverse.results.solrIsDown=Veuillez noter qu'en raison d'une erreur interne, les fonctions de consultation et de recherche ne sont pas disponibles.
 dataverse.theme.title=Thème
@@ -826,9 +826,9 @@ dataverse.theme.tagline.title=Une phrase qui décrit ce dataverse.
 dataverse.theme.tagline.tip=Fournir un titre d'appel de 140 caractères ou moins.
 dataverse.theme.website.title=L'adresse URL de votre site Web personnel ou de votre établissement ou de tout site Web associé à ce dataverse.
 dataverse.theme.website.tip=Le lien pour le site Web se trouvera derrière le titre d'appel. Pour qu'un site Web apparaisse dans la liste, vous devez également fournir un titre d'appel 
-dataverse.theme.website.watermark=Votre site personnel, http://...
+dataverse.theme.website.watermark=Votre site personnel, http://\u2026
 dataverse.theme.website.invalidMsg=Adresse URL non valide.
-dataverse.theme.disabled=Le thème du Dataverse racine a été désactivé administrativement via le paramètre de base de données ":DisableRootDataverseTheme".
+dataverse.theme.disabled=Le thème du Dataverse racine a été désactivé administrativement via le paramètre de base de données «\u00A0:DisableRootDataverseTheme\u00A0».
 dataverse.widgets.title=Widgets
 dataverse.widgets.notPublished.why.header=Pourquoi faire appel aux widgets?
 dataverse.widgets.notPublished.why.reason1=Augmente la visibilité de vos données sur le Web en vous permettant d'intégrer votre dataverse et les ensembles de données dans votre site web personnel ou de projet.
@@ -836,14 +836,14 @@ dataverse.widgets.notPublished.why.reason2=Permet aux autres de parcourir votre 
 dataverse.widgets.notPublished.how.header=Comment utiliser les widgets
 dataverse.widgets.notPublished.how.tip1=Pour pouvoir utiliser des widgets, votre dataverse et vos ensembles de données doivent être publiés.
 dataverse.widgets.notPublished.how.tip2=Suite à la publication, le code sera disponible sur cette page pour que vous puissiez le copier et l'ajouter à votre site web personnel ou de projet.
-dataverse.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l'ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title = "Adding Widgets to an OpenScholar Website - Dataverse User Guide" target ="_blank">ici</a>.
-dataverse.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Theme + Widgets - Dataverse User Guide" target="_blank">thème et widgets</a> du guide d'utilisation.
-dataverse.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Theme + Widgets - Dataverse User Guide" target="_blank">Thème et widgets</a> du guide d'utilisation.
+dataverse.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l'ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title = "Ajouter des widgets à un site web OpenScholar - Guide d'utilisation de Dataverse" target ="_blank">ici</a>.
+dataverse.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets - Guide d'utilisation de Dataverse" target="_blank">thème et widgets</a> du guide d'utilisation.
+dataverse.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets - Guide d'utilisation de Dataverse" target="_blank">Thème et widgets</a> du guide d'utilisation.
 dataverse.widgets.searchBox.txt=Boîte de recherche Dataverse
 dataverse.widgets.searchBox.tip=Permet aux visiteurs de votre site Web d'effectuer une recherche dans Dataverse.
 dataverse.widgets.dataverseListing.txt=Liste des dataverses
 dataverse.widgets.dataverseListing.tip=Permet aux visiteurs de votre site Web de voir vos dataverses et vos ensembles de données, de les trier ou de les parcourir en revue.
-dataverse.widgets.advanced.popup.header=Widgets: Options avancées
+dataverse.widgets.advanced.popup.header=Widgets\u00A0: Options avancées
 dataverse.widgets.advanced.prompt=Expédier vers votre site web personnel l'URL pérenne de la référence bibliographique de l'ensemble de données. La page que vous réferrez comme étant l'URL de votre site web personnel doit contenir l'extrait de code utilisé par le widget Listing de Dataverse.
 dataverse.widgets.advanced.url.label=URL de votre site web personnel
 dataverse.widgets.advanced.url.watermark=http://www.exemple.com/nom-de-la-page
@@ -851,12 +851,12 @@ dataverse.widgets.advanced.invalid.message=Veuillez saisir un URL valide
 dataverse.widgets.advanced.success.message=Mise à jour réussie de l'URL de votre site web personnel
 dataverse.widgets.advanced.failure.message=L'URL du site web personnel associé à ce dataverse n'a pas été mis à jour.
 
-# permissions-manage.xhtml=
+# permissions-manage.xhtml
 dataverse.permissions.title=Permissions
 dataverse.permissions.dataset.title=Permissions pour l'ensemble de données
 dataverse.permissions.access.accessBtn=Modifier l'accès
 dataverse.permissions.usersOrGroups=Utilisateurs/Groupes
-dataverse.permissions.requests=Requests
+dataverse.permissions.requests=Requêtes
 dataverse.permissions.usersOrGroups.assignBtn=Assigner les rôles aux utilisateurs/groupes
 dataverse.permissions.usersOrGroups.createGroupBtn=Créer un groupe
 dataverse.permissions.usersOrGroups.description=Tous les utilisateurs et les groupes qui ont accès à votre dataverse.
@@ -873,7 +873,7 @@ dataverse.permissions.roles.description=Tous les rôles établis dans votre datave
 dataverse.permissions.roles.edit=Modifier le rôle
 dataverse.permissions.roles.copy=Copier le rôle
 
-# permissions-manage-files.xhtml=
+# permissions-manage-files.xhtml
 dataverse.permissionsFiles.title=Permissions des fichiers à accès réservé
 dataverse.permissionsFiles.usersOrGroups=Utilisateurs/Groupes
 dataverse.permissionsFiles.usersOrGroups.assignBtn=Accorder l'accès aux utilisateurs/groupes
@@ -917,10 +917,10 @@ dataverse.permissionsFiles.assignDialog.fileName=Nom du fichier
 dataverse.permissionsFiles.assignDialog.grantBtn=Accorder
 dataverse.permissionsFiles.assignDialog.rejectBtn=Rejeter
 
-# permissions-configure.xhtml=
+# permissions-configure.xhtml
 dataverse.permissions.accessDialog.header=Modifier l'accès
 dataverse.permissions.description=Configuration actuelle de l'accès à votre dataverse.
-dataverse.permissions.tip=Sélectionnez, en cliquant sur le bouton «Modifier l'accès», si tous les utilisateurs ou seulement certains sont en mesure d'ajouter des données à ce dataverse. 
+dataverse.permissions.tip=Sélectionnez, en cliquant sur le bouton «\u00A0Modifier l'accès\u00A0», si tous les utilisateurs ou seulement certains sont en mesure d'ajouter des données à ce dataverse. 
 dataverse.permissions.Q1=Qui peut ajouter des données à ce dataverse?
 dataverse.permissions.Q1.answer1=Toute personne qui ajoute des données à ce dataverse doit y avoir accès.
 dataverse.permissions.Q1.answer2=Toute personne possédant un compte Dataverse peut ajouter des sous-dataverses.
@@ -930,9 +930,9 @@ dataverse.permissions.Q2=Lorsqu'un utilisateur ajoute un nouvel ensemble de donn
 dataverse.permissions.Q2.answer.editor.description=- Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, soumettre les ensembles de données aux fins d'examen.
 dataverse.permissions.Q2.answer.manager.description=- Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, les restrictions relatives aux fichiers (accès aux fichiers + utilisation)
 dataverse.permissions.Q2.answer.curator.description=- Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, les restrictions relatives aux fichiers (accès aux fichiers + utilisation), modifier les permissions/assigner les rôles + publier
-permission.anyoneWithAccount=Anyone with a Dataverse account
+permission.anyoneWithAccount=Toute personne possédant un compte Dataverse
 
-# roles-assign.xhtml=
+# roles-assign.xhtml
 dataverse.permissions.usersOrGroups.assignDialog.header=Assigner le rôle
 dataverse.permissions.usersOrGroups.assignDialog.description=Accorder les permissions aux utilisateurs et aux groupes en leur attribuant un rôle.
 dataverse.permissions.usersOrGroups.assignDialog.userOrGroup=Utilisateurs/groupes
@@ -943,7 +943,7 @@ dataverse.permissions.usersOrGroups.assignDialog.role.description=Voici les perm
 dataverse.permissions.usersOrGroups.assignDialog.role.warning=L'attribution du rôle {0} signifie que le ou les utilisateurs auront également le rôle {0} qui s'applique à tous les {1} dans ce {2}.
 dataverse.permissions.usersOrGroups.assignDialog.role.requiredMsg=Veuillez sélectionner un rôle à attribuer.
 
-# roles-edit.xhtml=
+# roles-edit.xhtml
 dataverse.permissions.roles.header=Modifier le rôle
 dataverse.permissions.roles.name=Nom du rôle
 dataverse.permissions.roles.name.title=Indiquer un nom pour le rôle.
@@ -954,7 +954,7 @@ dataverse.permissions.roles.description.counter={0} caractère(s) restant(s)
 dataverse.permissions.roles.roleList.header=Permissions du rôle
 dataverse.permissions.roles.roleList.authorizedUserOnly=Les permissions comportant l'icône Information indiquent que les actions peuvent être faites par des utilisateurs non authentifiés dans Dataverse.
 
-# explicitGroup-new-dialog.xhtml=
+# explicitGroup-new-dialog.xhtml
 dataverse.permissions.explicitGroupEditDialog.title.new=Créer un groupe
 dataverse.permissions.explicitGroupEditDialog.title.edit=Modifier le groupe {0}
 dataverse.permissions.explicitGroupEditDialog.help=Ajouter des utilisateurs ou d'autres groupes à ce groupe
@@ -971,7 +971,7 @@ dataverse.permissions.explicitGroupEditDialog.roleAssigneeName=Utilisateur/Group
 dataverse.permissions.explicitGroupEditDialog.roleAssigneeNames=Utilisateurs/Groupes
 dataverse.permissions.explicitGroupEditDialog.createGroup=Créer un groupe
 
-# manage-templates.xhtml=
+# manage-templates.xhtml
 dataset.manageTemplates.pageTitle=Gérer les modèles d'ensembles de données
 dataset.manageTemplates.select.txt=Intégrer des modèles provenant de {0}
 dataset.manageTemplates.createBtn=Créer un modèle d'ensemble de données
@@ -981,8 +981,8 @@ dataset.manageTemplates.noTemplates.why.reason1=Les modèles sont utiles lorsque 
 dataset.manageTemplates.noTemplates.why.reason2=Les modèles peuvent être utilisés pour entrer des directives à l'intention des personnes qui téléversent des ensembles de données dans votre dataverse si vous désirez qu'un champ de métadonnées soit rempli d'une façon particulière. 
 dataset.manageTemplates.noTemplates.how.header=Comment utiliser les modèles
 dataset.manageTemplates.noTemplates.how.tip1=Les modèles sont créés au niveau du dataverse, peuvent être supprimés (si on ne veut pas qu'ils paraissent dans les futurs ensembles de données), sont activés par défaut (non requis) et peuvent être copiés de façon à ce que vous n'ayez pas à recommencer du début lorsque vous créez un nouveau modèle contenant des métadonnées similaires à un autre modèle. Lorsqu'un modèle est supprimé, il n'y a aucune incidence sur les ensembles de données qui ont déjà utilisé le modèle.
-dataset.manageTemplates.noTemplates.how.tip2=Veuillez noter que la possibilité de choisir les champs de métadonnées qui seront cachés, obligatoires ou facultatifs est disponible sur la page <a href="/dataverse/{0}?editMode=INFO" title="Dataverse General Information">Renseignements généraux</a> de ce dataverse.
-dataset.manageTemplates.noTemplates.getStarted=Pour commencer, cliquez sur le bouton «Créer un modèle d'ensemble de données» ci-dessus. Pour en savoir plus au sujet des modèles, consultez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-templates" title="Dataset Templates - Dataverse User Guide" target="_blank">modèles d'ensembles de données</a>du guide d'utilisation.
+dataset.manageTemplates.noTemplates.how.tip2=Veuillez noter que la possibilité de choisir les champs de métadonnées qui seront cachés, obligatoires ou facultatifs est disponible sur la page <a href="/dataverse/{0}?editMode=INFO" title="Renseignements généraux sur Dataverse">Renseignements généraux</a> de ce dataverse.
+dataset.manageTemplates.noTemplates.getStarted=Pour commencer, cliquez sur le bouton «\u00A0Créer un modèle d'ensemble de données\u00A0» ci-dessus. Pour en savoir plus au sujet des modèles, consultez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-templates" title="Modèles d'ensemble de données - Guide d'utilisation de Dataverse" target="_blank">modèles d'ensemble de données</a>du guide d'utilisation.
 dataset.manageTemplates.tab.header.templte=Nom du modèle
 dataset.manageTemplates.tab.header.date=Date de création
 dataset.manageTemplates.tab.header.usage=Usage
@@ -1004,9 +1004,9 @@ dataset.manageTemplates.tab.action.noedit.createdin=Modèle créé pour {0}
 dataset.manageTemplates.delete.usedAsDefault=Ce modèle est le modèle par défaut du ou des dataverses suivants. Il sera également supprimé comme modèle par défaut.
 dataset.manageTemplates.info.message.notEmptyTable=Créer, cloner, modifier, voir ou supprimer des modèles d'ensembles de données. Créer un modèle d'ensemble de données où sont remplis au préalable certains champs de métadonnées au moyen de valeurs standards, comme l'affiliation de l'auteur, afin de faciliter l'ajout d'ensembles de données dans ce dataverse. Vous pouvez également ajouter du texte d'aide aux champs de métadonnées afin d'orienter les utilisateurs sur les éléments à ajouter à ces champs.
 
-# metadataFragment.xhtml=
+# metadataFragment.xhtml
 
-# template.xhtml=
+# template.xhtml
 dataset.template.name.tip=Le nom du modèle d'ensemble de données.
 dataset.template.returnBtn=Revenir à Gérer les modèles
 dataset.template.name.title=Indiquer un nom unique pour l'ensemble de données
@@ -1023,8 +1023,8 @@ dataverse.manageGroups.noGroups.why.reason1=Les groupes vous permettent d'attrib
 dataverse.manageGroups.noGroups.why.reason2=Vous pouvez faire appel aux groupes pour la gestion de différents types d'utilisateurs (étudiants, collaborateurs, etc.).
 dataverse.manageGroups.noGroups.how.header=Comment utiliser les groupes
 dataverse.manageGroups.noGroups.how.tip1=Un groupe peut comprendre à la fois des individus et d'autres groupes. 
-dataverse.manageGroups.noGroups.how.tip2=Vous pouvez attribuer des permissions à un groupe dans le volet « Permissions ». 
-dataverse.manageGroups.noGroups.getStarted=Pour débuter, cliquez sur le bouton « Créer un groupe » ci-dessus.
+dataverse.manageGroups.noGroups.how.tip2=Vous pouvez attribuer des permissions à un groupe dans le volet «\u00A0Permissions\u00A0». 
+dataverse.manageGroups.noGroups.getStarted=Pour débuter, cliquez sur le bouton «\u00A0Créer un groupe\u00A0» ci-dessus.
 dataverse.manageGroups.tab.header.name=Nom du groupe 
 dataverse.manageGroups.tab.header.id=Identifiant du groupe
 dataverse.manageGroups.tab.header.membership=Adhésion
@@ -1055,12 +1055,12 @@ dataset.manageGuestbooks.createBtn=Créer un registre des visiteurs pour l'ensemb
 dataset.manageGuestbooks.download.all.responses=Télécharger toutes les entrées
 dataset.manageGuestbooks.download.responses=Télécharger les entrées
 dataset.manageGuestbooks.noGuestbooks.why.header=Pourquoi utiliser des registres de visiteurs?
-dataset.manageGuestbooks.noGuestbooks.why.reason1=Les registres de visiteurs vous permettent de recueillir des données au sujet des personnes qui téléchargent les fichiers de vos ensembles de données. Vous pouvez recueillir des renseignements issus du compte (nom d'utilisateur, prénom et nom, affiliation, etc.) et créer des questions personnalisées (p.ex. À quoi serviront les données?)
+dataset.manageGuestbooks.noGuestbooks.why.reason1=Les registres de visiteurs vous permettent de recueillir des données au sujet des personnes qui téléchargent les fichiers de vos ensembles de données. Vous pouvez recueillir des renseignements issus du compte (nom d'utilisateur, prénom et nom, affiliation, etc.) et créer des questions personnalisées (p.\u00A0ex. À quoi serviront les données?)
 dataset.manageGuestbooks.noGuestbooks.why.reason2=Vous pouvez télécharger les données recueillies dans les registres de visiteurs activés afin de pouvoir les enregistrer en dehors de Dataverse.
 dataset.manageGuestbooks.noGuestbooks.how.header=Comment utiliser les registres de visiteurs
 dataset.manageGuestbooks.noGuestbooks.how.tip1=Un registre des visiteurs peut être utilisé pour plusieurs ensembles de données, mais un seul registre des visiteurs peut être utilisé pour un ensemble de données.
 dataset.manageGuestbooks.noGuestbooks.how.tip2=Les questions personnalisées peuvent comprendre des réponses en texte libre ou des questions à choice de réponses.
-dataset.manageGuestbooks.noGuestbooks.getStarted=Pour commencer, cliquer ci-dessus sur le bouton «Créer un registre des visiteurs pour l'ensemble de données». Pour en savoir plus sur les registres de visiteurs, visitez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-guestbooks" title="Dataset Guestbook - Dataverse User Guide" target="_blank">registre des visiteurs</a> du guide d'utilisation.
+dataset.manageGuestbooks.noGuestbooks.getStarted=Pour commencer, cliquer ci-dessus sur le bouton «\u00A0Créer un registre des visiteurs pour l'ensemble de données\u00A0». Pour en savoir plus sur les registres de visiteurs, visitez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-guestbooks" title="Registre des visiteurs de l'ensemble de données - Guide d'utilisation de Dataverse" target="_blank">registre des visiteurs</a> du guide d'utilisation.
 dataset.manageGuestbooks.tab.header.name=Nom du registre des visiteurs
 dataset.manageGuestbooks.tab.header.date=Date de création
 dataset.manageGuestbooks.tab.header.usage=Usage
@@ -1092,7 +1092,7 @@ dataset.manageGuestbooks.message.enableFailure=Le registre des visiteurs ne peut
 dataset.manageGuestbooks.message.disableSuccess=Le registre des visiteurs a été désactivé.
 dataset.manageGuestbooks.message.disableFailure=Le registre des visiteurs ne peut pas être désactivé.
 dataset.manageGuestbooks.tip.title=Gérer les registres de visiteurs des ensembles de données
-dataset.manageGuestbooks.tip.downloadascsv=Cliquer sur «Télécharger toutes les entrées» pour télécharger dans un fichier CSV toutes les entrées recueillies dans le registre de visiteurs de ce dataverse. Pour naviguer et analyser les données ainsi collectées, nous vous recommandons d'importer ce fichier CSV dans Excel, Google Sheets ou un logiciel similaire.
+dataset.manageGuestbooks.tip.downloadascsv=Cliquer sur «\u00A0Télécharger toutes les entrées\u00A0» pour télécharger dans un fichier CSV toutes les entrées recueillies dans le registre de visiteurs de ce dataverse. Pour naviguer et analyser les données ainsi collectées, nous vous recommandons d'importer ce fichier CSV dans Excel, Google Sheets ou un logiciel similaire.
 dataset.guestbooksResponses.dataset=Ensemble de données
 dataset.guestbooksResponses.date=Date
 dataset.guestbooksResponses.type=Type
@@ -1100,8 +1100,8 @@ dataset.guestbooksResponses.file=Fichier
 dataset.guestbooksResponses.tip.title=Entrées du registre de visiteur
 dataset.guestbooksResponses.count.responses={0} {0, choice, 0#Entrées|1#Entrée|2#Entrées}
 dataset.guestbooksResponses.count.toofresults={0} à {1} de {2} {2, choice, 0#Entrées|1#Entrée|2#Entrées}
-dataset.guestbooksResponses.tip.downloadascsv=Cliquer sur «Télécharger les entrées» pour télécharger dans un fichier CSV les entrées recueillies dans le registre de visiteurs de ce dataverse. Pour naviguer et analyser les données ainsi collectées, nous vous recommandons d'importer ce fichier CSV dans Excel, Google Sheets ou un logiciel similaire.
-dataset.guestbooksResponses.tooManyResponses.message=Note: ce registre de visiteurs contient trop d'entrées pour qu'elles puissent être affichées entièrement sur cette page. Seules les {0} entrées les plus récentes sont affichées ci-dessous. Cliquez sur «Télécharger les entrées» pour télécharger toutes les entrées recueillies ({1} au total) en tant que fichier CSV.
+dataset.guestbooksResponses.tip.downloadascsv=Cliquer sur «\u00A0Télécharger les entrées\u00A0» pour télécharger dans un fichier CSV les entrées recueillies dans le registre de visiteurs de ce dataverse. Pour naviguer et analyser les données ainsi collectées, nous vous recommandons d'importer ce fichier CSV dans Excel, Google Sheets ou un logiciel similaire.
+dataset.guestbooksResponses.tooManyResponses.message=Note\u00A0: ce registre de visiteurs contient trop d'entrées pour qu'elles puissent être affichées entièrement sur cette page. Seules les {0} entrées les plus récentes sont affichées ci-dessous. Cliquez sur «\u00A0Télécharger les entrées\u00A0» pour télécharger toutes les entrées recueillies ({1} au total) en tant que fichier CSV.
 
 # guestbook-responses.xhtml
 dataset.guestbookResponses.pageTitle=Entrées du registre de visiteur
@@ -1148,7 +1148,7 @@ dataset.exportBtn.itemLabel.schemaDotOrg=Schema.org JSON-LD
 dataset.exportBtn.itemLabel.json=JSON
 metrics.title=Statistiques
 metrics.title.tip=Afficher plus d'informations sur les statistiques d'utilisation
-metrics.comingsoon=Bientôt disponible...
+metrics.comingsoon=Bientôt disponible\u2026
 metrics.views=Pages consultées
 metrics.downloads={0, choice, 0#téléchargements|1#téléchargement|2#téléchargements}
 metrics.citations=Citations
@@ -1172,7 +1172,7 @@ dataset.reject.enterReason.header=Entrée obligatoire
 dataset.reject.success=Cet ensemble de données à été renvoyé au collaborateur.
 dataset.reject.failure=Échec de la soumission du renvoi de l'ensemble de données - {0}
 dataset.reject.datasetNull=Impossible de renvoyer l'ensemble de données à l'auteur (s) car il est null.
-dataset.reject.datasetNotInReview=Cet ensemble de données ne peut pas être renvoyé à (aux) l'auteur (s), car la dernière version n'est pas en révision. L' (les) auteur(s) doit (doivent) d'abord cliquer sur «Soumettre pour révision».
+dataset.reject.datasetNotInReview=Cet ensemble de données ne peut pas être renvoyé à (aux) l'auteur (s), car la dernière version n'est pas en révision. L' (les) auteur(s) doit (doivent) d'abord cliquer sur «\u00A0Soumettre pour révision\u00A0».
 dataset.publish.tip=Êtes-vous sûr(e) de vouloir publier cet ensemble de données? Une fois publié, il doit demeurer publié.
 dataset.publishBoth.tip=Une fois que vous publiez cet ensemble de données, il doit demeurer publié.
 dataset.unregistered.tip=Cet ensemble de données n'est pas enregistré. Nous tenterons de l'enregistrer avant de le publier.
@@ -1199,21 +1199,21 @@ dataset.locked.message=Ensemble de données verrouillé
 dataset.locked.inReview.message=Soumis pour révision
 dataset.publish.error=L'ensemble de données ne peut être publié, car le service de <a href=\{1} target=\"_blank\"/> {0} </a> est actuellement inaccessible. Veuillez essayer à nouveau. Le problème persiste-il? 
 dataset.publish.error.doi=L'ensemble de données ne peut être retiré, car la mise à jour DOI a échoué. 
-dataset.compute.computeBatchSingle=Compute Dataset
-dataset.compute.computeBatchList=List Batch
-dataset.compute.computeBatchAdd=Add to Batch
-dataset.compute.computeBatchClear=Clear Batch
-dataset.compute.computeBatchRemove=Remove from Batch
-dataset.compute.computeBatchCompute=Compute Batch
-dataset.compute.computeBatch.success=The list of datasets in your compute batch has been updated.
-dataset.compute.computeBatch.failure=The list of datasets in your compute batch failed to be updated. Please try again.
-dataset.compute.computeBtn=Compute
-dataset.compute.computeBatchListHeader=Compute Batch
-dataset.compute.computeBatchRestricted=This dataset contains restricted files you may not compute on because you have not been granted access.
-dataset.delete.error=L'ensemble de données ne peut être publié, car la mise à jour {0} a échoué.
+dataset.compute.computeBatchSingle=Calcul de l'ensemble de données
+dataset.compute.computeBatchList=Lister lot
+dataset.compute.computeBatchAdd=Ajouter au lot
+dataset.compute.computeBatchClear=Vider le lot
+dataset.compute.computeBatchRemove=Supprimer du lot
+dataset.compute.computeBatchCompute=Calculer le lot
+dataset.compute.computeBatch.success=La liste des ensembles de données de votre lot de calcul a été mise à jour.
+dataset.compute.computeBatch.failure=Échec de la mise à jour de la liste des ensembles de données de votre lot de calcul. Veuillez essayer de nouveau.
+dataset.compute.computeBtn=Calculer
+dataset.compute.computeBatchListHeader=Calcul du lot
+dataset.compute.computeBatchRestricted=Cet ensemble de données contient des fichiers à accès restreint sur lesquels vous ne pouvez y effectuer un calcul puisque vous ne bénéficiez pas des autorisations nécessaires.
+dataset.delete.error=L'ensemble de données ne peut être retiré, car la mise à jour {0} a échoué.
 dataset.publish.worldMap.deleteConfirm=Veuillez noter que vos données et votre carte sur WorldMap seront supprimées en raison de modifications des restrictions d'accès aux fichiers dans cette version de l'ensemble de données que vous publiez. Voulez-vous continuer?
 dataset.publish.workflow.inprogress=Publier le flux de travail en cours
-dataset.pidRegister.workflow.inprogress=Register/update file persistent identifiers workflow in progress
+dataset.pidRegister.workflow.inprogress=Enregistrement/mise à jour du flux de travail des identifiants persistants en cours
 dataset.versionUI.draft=Version provisoire
 dataset.versionUI.inReview=En révision
 dataset.versionUI.unpublished=Non publiée
@@ -1221,35 +1221,35 @@ dataset.versionUI.deaccessioned=Retirée
 dataset.cite.title.released=La VERSION PROVISOIRE sera remplacée dans la référence bibliographique par la V1 une fois l'ensemble de données publié.
 dataset.cite.title.draft=La VERSION PROVISOIRE sera remplacée dans la référence bibliographique par la version sélectionnée une fois l'ensemble de données publié.
 dataset.cite.title.deassessioned=La mention VERSION RETIRÉE a été ajoutée à la référence bibliographique pour cette version étant donné qu'elle n'est plus disponible.
-dataset.cite.standards.tip=Learn about <a href="https://dataverse.org/best-practices/data-citation" title="Data Citation - Dataverse.org" target="_blank">Data Citation Standards</a>.
+dataset.cite.standards.tip=Pour en apprendre davantage sur le sujet, consultez le document <a href="https://dataverse.org/best-practices/data-citation" title="Data Citation  - Dataverse Best Practices" target="_blank">Data Citation Standards [en]</a>.
 dataset.cite.downloadBtn=Citer l'ensemble de données
 dataset.cite.downloadBtn.xml=EndNote XML
 dataset.cite.downloadBtn.ris=RIS
 dataset.cite.downloadBtn.bib=BibTeX
 dataset.create.authenticatedUsersOnly=Seuls les utilisateurs authentifiés peuvent créer des ensembles de données.
 dataset.deaccession.reason=Raison du retrait
-dataset.beAccessedAt=L'ensemble de données peut maintenant être consulté à:
+dataset.beAccessedAt=L'ensemble de données peut maintenant être consulté à\u00A0:
 dataset.descriptionDisplay.title=Description
 dataset.keywordDisplay.title=Mot-clé
 dataset.subjectDisplay.title=Sujet
 dataset.contact.tip=Utiliser le bouton de courriel ci-dessus pour communiquer avec cette personne. 
 dataset.asterisk.tip=Les astérisques indiquent les champs obligatoires.
 dataset.message.uploadFiles=Téléverser les fichiers de l'ensemble de données - Vous pouvez glisser-déplacer les fichiers à partir de votre ordinateur vers le widget de téléversement. 
-dataset.message.editMetadata=Modifier les métadonnées de l'ensemble de données: ajouter plus de métadonnées afin de faciliter le repérage de cet ensemble.
-dataset.message.editTerms=Modifier les conditions de l'ensemble de données: mettre à jour les conditions d'utilisation de cet ensemble de données.
+dataset.message.editMetadata=Modifier les métadonnées de l'ensemble de données\u00A0: ajouter plus de métadonnées afin de faciliter le repérage de cet ensemble.
+dataset.message.editTerms=Modifier les conditions de l'ensemble de données\u00A0: mettre à jour les conditions d'utilisation de cet ensemble de données.
 dataset.message.locked.editNotAllowedInReview=L'ensemble de données ne peut pas être modifié en raison du verrouillage de l'ensemble de données en révision.
 dataset.message.locked.downloadNotAllowedInReview=Les fichiers de l'ensemble de données ne peuvent pas être téléchargés en raison du verrouillage de l'ensemble de données en révision.
 dataset.message.locked.downloadNotAllowed=Les fichiers de l'ensemble de données ne peuvent pas être téléchargés en raison du verrouillage de l'ensemble de données.
 dataset.message.locked.editNotAllowed=L'ensemble de données ne peut pas être édité en raison de son verrouillage.
 dataset.message.createSuccess=Cet ensemble de données a été créé
-dataset.message.createSuccess.failedToSaveFiles=Partial Success: The dataset has been created. But the file(s) could not be saved. Please try uploading the file(s) again.
-dataset.message.createSuccess.partialSuccessSavingFiles=Partial Success: The dataset has been created. But only {0} out of {1} files have been saved. Please try uploading the missing file(s) again.
+dataset.message.createSuccess.failedToSaveFiles=Succès partiel\u00A0: l'ensemble de données a été créé. Mais le(s) fichier(s) n'a(ont) pas pu être sauvegardé(s). Veuillez réessayer de téléverser le(s) fichier(s) de nouveau.
+dataset.message.createSuccess.partialSuccessSavingFiles=Succès partiel\u00A0: l'ensemble de données a été créé. Mais seul(s) {0} sur {1} fichier(s) a(ont) été enregistré(s). Veuillez réessayer de téléverser le(s) fichier(s) manquant(s) de nouveau.
 dataset.message.linkSuccess=Cet ensemble de données est maintenant lié à {1}.
 dataset.message.metadataSuccess=Les métadonnées de cet ensemble de données ont été mises à jour.
 dataset.message.termsSuccess=Les conditions de cet ensemble de données ont été mises à jour.
 dataset.message.filesSuccess=Les fichiers de cet ensemble de données ont été mis à jour.
-dataset.message.addFiles.Failure=Failed to add files to the dataset. Please try uploading the file(s) again.
-dataset.message.addFiles.partialSuccess=Partial success: only {0} files out of {1} have been saved. Please try uploading the missing file(s) again.
+dataset.message.addFiles.Failure=Impossible d'ajouter des fichiers à l'ensemble de données. Veuillez réessayer de télécharger le(s) fichier(s) de nouveau. 
+dataset.message.addFiles.partialSuccess=Succès partiel\u00A0: seul(s) {0} sur {1} fichier(s) a(ont) été enregistré(s). Veuillez réessayer de téléverser le(s) fichier(s) manquant(s) de nouveau.
 dataset.message.publishSuccess=Cet ensemble de données a été publié. 
 dataset.message.only.authenticatedUsers=Seuls les utilisateurs authentifiés peuvent publier des ensembles de données. 
 dataset.message.deleteSuccess=Cet ensemble de données a été supprimé. 
@@ -1272,9 +1272,9 @@ dataset.message.publicInstall=Accès aux fichiers - Les fichiers sont stockés sur
 dataset.metadata.publicationDate=Date de publication
 dataset.metadata.publicationDate.tip=La date de publication d'un ensemble de données.
 dataset.metadata.persistentId=Identifiant pérenne de l'ensemble de données
-dataset.metadata.persistentId.tip=The unique persistent identifier for a dataset, which can be a Handle or DOI in Dataverse.
-file.metadata.persistentId=File Persistent ID
-file.metadata.persistentId.tip=The unique persistent identifier for a file, which can be a Handle or DOI in Dataverse.
+dataset.metadata.persistentId.tip=L'identifiant unique permanent pour un ensemble de données, lequel peut être dans Dataverse un Handle ou un DOI.
+file.metadata.persistentId=Identifiant permanent du fichier
+file.metadata.persistentId.tip=L'identifiant unique permanent pour un fichier, lequel peut être dans Dataverse un Handle ou un DOI.
 dataset.versionDifferences.termsOfUseAccess=Conditions d'utilisation et d'accès
 dataset.versionDifferences.termsOfUseAccessChanged=Conditions d'utilisation et d'accès modifiées
 file.viewDiffDialog.restricted=Accès réservé
@@ -1291,11 +1291,11 @@ dataset.inValidSelectedFilesForDownload=Fichiers réservés sélectionnés
 dataset.noValidSelectedFilesForDownload=Le ou les fichiers réservés sélectionnés ne peuvent être téléchargés, car les accès ne vous ont pas été accordés.
 dataset.mixedSelectedFilesForDownload=Le ou les fichiers réservés sélectionnés ne peuvent être téléchargés, car les accès ne vous ont pas été accordés.
 dataset.downloadUnrestricted=Cliquez sur Continuer pour télécharger les fichiers pour lesquels vous avez un accès.
-dataset.requestAccessToRestrictedFiles=Vous pouvez demander l'accès à un ou des fichiers réservés en cliquant sur le bouton « Demander l'accès ».
-dataset.privateurl.infoMessageAuthor=URL privé de l'ensemble de données non publié - Partager en privé cet ensemble de données avant sa publication: {0}
+dataset.requestAccessToRestrictedFiles=Vous pouvez demander l'accès à un ou des fichiers réservés en cliquant sur le bouton «\u00A0Demander l'accès\u00A0».
+dataset.privateurl.infoMessageAuthor=URL privé de l'ensemble de données non publié - Partager en privé cet ensemble de données avant sa publication\u00A0: {0}
 dataset.privateurl.infoMessageReviewer=URL privé de l'ensemble de données non publié -  Cet ensemble de données non publié est partagé en privé. Vous ne pourrez pas y accéder lorsque connecté à votre compte Dataverse.
 dataset.privateurl.header=URL privée de l'ensemble de données non publié
-dataset.privateurl.tip=Utilisez une adresse URL privée pour permettre à ceux qui n'ont pas de compte Dataverse d'accéder à votre ensemble de données non publié. Pour plus d'informations sur la fonctionnalité d'URL privé, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#private-url-for-reviewing-an-unpublished-dataset" title="Private URL for Reviewing an Unpublished Dataset - Dataverse User Guide" target="_blank">guide d'utilisation</a>.
+dataset.privateurl.tip=Utilisez une adresse URL privée pour permettre à ceux qui n'ont pas de compte Dataverse d'accéder à votre ensemble de données non publié. Pour plus d'informations sur la fonctionnalité d'URL privé, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#private-url-for-reviewing-an-unpublished-dataset" title="URL privé pour vérifier un esmeble de données non publié - Guide d'utilisation de Dataverse" target="_blank">guide d'utilisation</a>.
 dataset.privateurl.absent=L'adresse URL privée n'a pas été créée.
 dataset.privateurl.createPrivateUrl=Créer une adresse URL privée
 dataset.privateurl.disablePrivateUrl=Désactiver l'URL privé
@@ -1305,20 +1305,20 @@ dataset.privateurl.cannotCreate=L'URL privé ne peut être utilisé qu'avec des ver
 dataset.privateurl.roleassigeeTitle=URL privé activé
 dataset.privateurl.createdSuccess=Opération réussie!
 dataset.privateurl.disabledSuccess=Vous avez bien désactivé l'URL privé de cet ensemble de données non publié.
-dataset.privateurl.noPermToCreate=Pour créer une adresse URL privé, vous devez disposer des autorisations suivantes: {0}.
+dataset.privateurl.noPermToCreate=Pour créer une adresse URL privé, vous devez disposer des autorisations suivantes\u00A0: {0}.
 file.count={0} {0, choice, 0#Fichiers|1#Fichiers|2#Fichiers}
 file.count.selected={0} {0, choice, 0#Fichiers sélectionnés|1#Fichier sélectionné|2#Fichiers sélectionnés}
 file.selectToAddBtn=Sélectionner les fichiers à ajouter
 file.selectToAdd.tipLimit=La limite de téléversement est de {0} octets par fichier.
-file.selectToAdd.tipMoreInformation=Pour plus d'informations sur les formats de fichiers pris en charge, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#file-handling-and-uploading" title="File Handling and Uploading - Dataverse User Guide" target="_blank">guide d'utilisation</a>.
+file.selectToAdd.tipMoreInformation=Pour plus d'informations sur les formats de fichiers pris en charge, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#file-handling-and-uploading" title="Manipulation et téléversement de fichiers - Guide d'utilisation de Dataverse" target="_blank">guide d'utilisation</a>.
 file.selectToAdd.dragdropMsg=Glisser et déposer les fichiers ici.
-file.createUploadDisabled=Une fois que vous avez sauvegardé votre ensemble de données, vous pouvez téléverser vos données en utilisant le bouton «Téléverser des fichiers» sur la page de l'ensemble de données. Pour plus d'informations sur les formats de fichiers pris en charge, reportez-vous au guide d'utilisation.
+file.createUploadDisabled=Une fois que vous avez sauvegardé votre ensemble de données, vous pouvez téléverser vos données en utilisant le bouton «\u00A0Téléverser des fichiers\u00A0» sur la page de l'ensemble de données. Pour plus d'informations sur les formats de fichiers pris en charge, reportez-vous au guide d'utilisation.
 file.fromDropbox=Téléverser à partir de Dropbox
 file.fromDropbox.tip=Les fichiers peuvent aussi être téléverser directement de Dropbox.
 file.replace.original=Original File
 file.editFiles=Modifier les fichiers
-file.editFilesSelected=Edit
-file.editFile=Edit
+file.editFilesSelected=Modifier
+file.editFile=Modifier
 file.bulkUpdate=Chargement en lot
 file.uploadFiles=Téléverser des fichiers
 file.replaceFile=Remplacer le fichier
@@ -1332,42 +1332,42 @@ file.replaced.warning.previous.warningMessage=Vous ne pouvez pas éditer un fichi
 file.alreadyDeleted.previous.warningMessage=Ce fichier a déjà été supprimé dans la version actuelle. Il peut ne pas être modifié.
 file.delete=Supprimer
 file.metadata=Métadonnées
-file.deleted.success=En cliquant sur «Enregistrer les modifications», les fichiers "{0}" seront supprimés de façon permanente de cette version de l'ensemble de données.
+file.deleted.success=En cliquant sur «\u00A0Enregistrer les modifications\u00A0», les fichiers «\u00A0{0}\u00A0» seront supprimés de façon permanente de cette version de l'ensemble de données.
 file.deleted.replacement.success=Le fichier de remplacement a été supprimé.
 file.editAccess=Modifier les accès
 file.restrict=Restreindre
 file.unrestrict=Sans restriction
-file.restricted.success=L'accès aux fichiers "{0}" sera restreint du moment où vous cliquerez sur le bouton «Enregistrer les modifications» au bas de la page.
+file.restricted.success=L'accès aux fichiers «\u00A0{0}\u00A0» sera restreint du moment où vous cliquerez sur le bouton «\u00A0Enregistrer les modifications\u00A0» au bas de la page.
 file.download.header=Télécharger
 file.download.subset.header=Télécharger le sous-ensemble de données
-file.preview=Aperçu:
-file.previewMap=Aperçu de la carte:
+file.preview=Aperçu\u00A0:
+file.previewMap=Aperçu de la carte\u00A0:
 file.fileName=Nom du fichier
 file.type.tabularData=Données tabulaires
 file.originalChecksumType=Fichier original {0}
 file.checksum.exists.tip=Un fichier avec cette somme de contrôle existe déjà dans l'ensemble de données.
 file.selectedThumbnail=Vignette
-file.selectedThumbnail.tip=La vignette associée au fichier est utilisée comme vignette par défaut pour l'ensemble de données. Cliquez sur le bouton «Options avancées» d'un autre fichier pour sélectionner ce fichier.
+file.selectedThumbnail.tip=La vignette associée au fichier est utilisée comme vignette par défaut pour l'ensemble de données. Cliquez sur le bouton «\u00A0Options avancées\u00A0» d'un autre fichier pour sélectionner ce fichier.
 file.cloudStorageAccess=Accès au stockage infonuagique
 file.cloudStorageAccess.tip=Le nom du conteneur pour cet ensemble de données doit accéder aux fichiers dans le stockage infonuagique.
-file.cloudStorageAccess.help=Pour accéder directement à ces données dans l'environnement infonuagique {2}, utilisez le nom du conteneur dans la case d'accès au stockage infonuagique ci-dessous. Pour en savoir plus sur l'environnement infonuagique, consultez la section <a href="{0}/{1}/user/dataset-management.html#cloud-storage" title="Cloud Storage Access - Dataverse User Guide" target="_blank">accès au stockage infonuagique</a> du guide d'utilisation.
+file.cloudStorageAccess.help=Pour accéder directement à ces données dans l'environnement infonuagique {2}, utilisez le nom du conteneur dans la case d'accès au stockage infonuagique ci-dessous. Pour en savoir plus sur l'environnement infonuagique, consultez la section <a href="{0}/{1}/user/dataset-management.html#cloud-storage" title="Accès au stockage en infonuagique - Guide d'utilisation de Dataverse" target="_blank">accès au stockage infonuagique</a> du guide d'utilisation.
 file.copy=Copier
 file.compute=Calculer
-file.rsyncUpload.info=Veuillez suivre ces étapes pour téléverser vos données. Pour en apprendre davantage sur le processus de téléversement et sur comment préparer vos données, veuillez vous reporter à la section <a href = "{0}/{1}/user/dataset-management.html#file-handling-and-uploading" title = "File Handling and Uploading - Dataverse User Guide" target ="_ blank">Manipulation et téléchargement de fichiers</a> du guide d'utilisation.
+file.rsyncUpload.info=Veuillez suivre ces étapes pour téléverser vos données. Pour en apprendre davantage sur le processus de téléversement et sur comment préparer vos données, veuillez vous reporter à la section <a href = "{0}/{1}/user/dataset-management.html#file-handling-and-uploading" title = "Manipulation et téléchargement de fichiers - Guide d'utilisation de Dataverse" target ="_ blank">Manipulation et téléchargement de fichiers</a> du guide d'utilisation.
 file.rsyncUpload.noScriptAvailable=Le script Rsync n'est pas disponible!
 file.rsyncUpload.filesExist=Vous ne pouvez pas téléverser des fichiers supplémentaires dans cet ensemble de données.
 file.rsyncUpload.step1=Assurez-vous que vos données sont stockées dans un seul répertoire. Tous les fichiers de ce répertoire et de ses sous-répertoires seront téléversés dans votre ensemble de données.
-file.rsyncUpload.step2=Télécharger ce script de téléversement de fichiers:
+file.rsyncUpload.step2=Télécharger ce script de téléversement de fichiers\u00A0:
 file.rsyncUpload.step2.downloadScriptButton=Télécharger le script
-file.rsyncUpload.step3=Ouvrir une fenêtre de terminal dans le même répertoire que celui où vous avez enregistré le script et exécuter cette commande: <code> bash ./{0} </code>
-file.rsyncUpload.step4=Suivre les instructions du script. Il vous sera demandé un chemin complet (commençant par "/") vers le répertoire contenant vos données. Note: ce script expirera après 7 jours.
+file.rsyncUpload.step3=Ouvrir une fenêtre de terminal dans le même répertoire que celui où vous avez enregistré le script et exécuter cette commande\u00A0: <code> bash ./{0} </code>
+file.rsyncUpload.step4=Suivre les instructions du script. Il vous sera demandé un chemin complet (commençant par  «\u00A0/\u00A0») vers le répertoire contenant vos données. Note\u00A0: ce script expirera après 7 jours.
 file.rsyncUpload.inProgressMessage.summary=Téléchargement de fichier DCM
 file.rsyncUpload.inProgressMessage.details=Cet ensemble de données est verrouillé jusqu'à ce que les fichiers de données aient été transférés et vérifiés.
 
 file.metaData.dataFile.dataTab.variables=Variables
 file.metaData.dataFile.dataTab.observations=Observations
 file.metaData.viewOnWorldMap=Explorer sur WorldMap
-file.addDescription=Ajouter une description au fichier...
+file.addDescription=Ajouter une description au fichier\u2026
 file.tags=Libellés
 file.editTags=Libellés
 file.editTagsDialog.tip=Sélectionner les libellés de fichier existants ou créer de nouveaux libellés pour décrire vos fichiers. Chaque fichier peut avoir plus d'un libellé.
@@ -1376,7 +1376,7 @@ file.editTagsDialog.selectedTags=Libellés sélectionnés
 file.editTagsDialog.selectedTags.none=Aucun libellé sélectionné
 file.editTagsDialog.add=Personnaliser le libellé du fichier
 file.editTagsDialog.add.tip=Créer un nouveau libellé l'ajoutera comme option de libellé pour tous les fichiers de cet ensemble de données.
-file.editTagsDialog.newName=Ajouter un nouveau libellé de fichier...
+file.editTagsDialog.newName=Ajouter un nouveau libellé de fichier\u2026
 dataset.removeUnusedFileTags.label=Supprimer les libellés
 dataset.removeUnusedFileTags.tip=Sélectionner pour supprimer les libellés personnalisés non utilisés par les fichiers de l'ensemble de données.
 dataset.removeUnusedFileTags.check=Supprimer les libellés non utilisés
@@ -1394,7 +1394,7 @@ file.tabularDataTags=Libellés des données tabulaires
 file.tabularDataTags.tip=Sélectionner un ou plusieurs libellés décrivant le type de fichier de données.
 file.spss-savEncoding=Encodage linguistique
 file.spss-savEncoding.title=Sélectionner la langue utilisée pour encoder ce fichier de données SPSS (sav).
-file.spss-savEncoding.current=Sélection actuelle:
+file.spss-savEncoding.current=Sélection actuelle\u00A0:
 file.spss-porExtraLabels=Libellés de variable
 file.spss-porExtraLabels.title=Téléverser un fichier texte supplémentaire contenant des libellés de variable supplémentaires.
 file.spss-porExtraLabels.selectToAddBtn=Sélectionner le fichier à ajouter
@@ -1411,16 +1411,16 @@ file.downloadBtn.format.original=Format du fichier original ({0})
 file.downloadBtn.format.rdata=Format RData
 file.downloadBtn.format.var=Métadonnées des variables
 file.downloadBtn.format.citation=Référence bibliographique du fichier de données
-file.downloadBtn.format.datasubset=Data Subset
-file.more.information.link=Mettre un lien vers plus d'information sur le fichier: 
+file.downloadBtn.format.datasubset=Sous-ensemble de données
+file.more.information.link=Mettre un lien vers plus d'information sur le fichier\u00A0: 
 file.requestAccess=Demander l'accès
-file.requestAccess.dialog.msg=Vous devez <a href="/loginpage.xhtml{0}" title="vous connecter à votre compte Dataverse">vous authentifier</a> pour demander un accès à ce fichier.
-file.requestAccess.dialog.msg.signup=You need to <a href="{0}" target="{1}" title="Sign Up for a Dataverse Account">Sign Up</a> or <a href="/loginpage.xhtml{0}" target="{1}" title="Log into your Dataverse Account">Log In</a> to request access to this file.
+file.requestAccess.dialog.msg=Vous devez <a href="/loginpage.xhtml{0}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour demander un accès à ce fichier.
+file.requestAccess.dialog.msg.signup=Vous devez <a href="{0}" target="{1}" title="Inscrivez-vous pour ouvrir un compte Dataverse">ouvrir un compte</a> ou <a href="/loginpage.xhtml{0}" target="{1}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour demander un accès à ce fichier.
 file.accessRequested=Accès demandé
 file.restrictions=Restrictions d'accès aux fichiers
 file.restrictions.description=Limiter l'accès aux fichiers publiés en les indiquant comme étant restreints. Fournir aux utilisateurs les Conditions d'accès et leur permettre de demander l'accès.
 file.restrictions.worldmap.warning=Veuillez noter que, une fois vos modifications d'accès au fichier publiées, votre carte sur WorldMap sera supprimée et la fonction Explorer sur WorldMap sera retirée.
-file.ingestInProgress=Chargement en cours...
+file.ingestInProgress=Chargement en cours\u2026
 file.dataFilesTab.metadata.header=Métadonnées
 file.dataFilesTab.metadata.addBtn=Ajouter + Modifier les métadonnées
 file.dataFilesTab.terms.header=Conditions
@@ -1428,21 +1428,21 @@ file.dataFilesTab.terms.editTermsBtn=Modifier les conditions
 file.dataFilesTab.terms.list.termsOfUse.header=Conditions d'utilisation
 file.dataFilesTab.terms.list.termsOfUse.waiver=Licence accordée
 file.dataFilesTab.terms.list.termsOfUse.waiver.title=La licence permet d'informer les utilisateurs de ce qui leur est permis de faire avec ces données téléchargées. 
-file.dataFilesTab.terms.list.termsOfUse.waiver.txt=licence CC0 - "Transfert dans le domaine public"
-file.dataFilesTab.terms.list.termsOfUse.waiver.description=Datasets will default to a <a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Public Domain Dedication - Creative Commons" target="_blank">CC0 public domain dedication </a>. CC0 facilitates reuse and extensibility of research data. Our <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Dataverse Community Norms - Dataverse.org" target="_blank">Community Norms</a> as well as good scientific practices expect that proper credit is given via citation. If you are unable to give datasets a CC0 waiver you may enter custom Terms of Use for datasets. 
+file.dataFilesTab.terms.list.termsOfUse.waiver.txt=licence CC0 - «\u00A0Transfert dans le domaine public\u00A0»
+file.dataFilesTab.terms.list.termsOfUse.waiver.description=Les ensembles de données se verront attribuer par défaut une <a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Transfert dans le domaine public - Creative Commons" target="_blank">licence CC0 - Transfert dans le domaine public</a>. CC0 facilite la réutilisation et l'extensibilité des données de recherche. Nos <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Normes de la communauté Dataverse - Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Si vous ne pouvez accorder une licence CC0, vous pouvez établir des conditions d'utilisation personnalisées pour vos ensembles de données. 
 file.dataFilesTab.terms.list.termsOfUse.no.waiver.txt=Aucune licence n'a été sélectionnée pour cet ensemble de données. 
-file.dataFilesTab.terms.list.termsOfUse.waiver.txt.description=Our <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Dataverse Community Norms - Dataverse.org" target="_blank">Community Norms</a> as well as good scientific practices expect that proper credit is given via citation. Please use the data citation above, generated by the Dataverse.
-file.dataFilesTab.terms.list.termsOfUse.waiver.select.CCO=Oui, appliquer la licence CC0 - «Transfert dans le domaine public».
-file.dataFilesTab.terms.list.termsOfUse.waiver.select.notCCO=Non, ne pas appliquer la licence CC0 - «Transfert dans le domaine public».
+file.dataFilesTab.terms.list.termsOfUse.waiver.txt.description=Les <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Normes de la communauté Dataverse - Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Veuillez utiliser la référence bibliographique ci-dessus générée par Dataverse.
+file.dataFilesTab.terms.list.termsOfUse.waiver.select.CCO=Oui, appliquer la licence CC0 - «\u00A0Transfert dans le domaine public\u00A0».
+file.dataFilesTab.terms.list.termsOfUse.waiver.select.notCCO=Non, ne pas appliquer la licence CC0 - «\u00A0Transfert dans le domaine public\u00A0».
 file.dataFilesTab.terms.list.termsOfUse.waiver.select.tip=Voici ce que les utilisateurs finaux verront affiché pour cet ensemble de données.
 file.dataFilesTab.terms.list.termsOfUse.termsOfUse=Conditions d'utilisation
 file.dataFilesTab.terms.list.termsOfUse.termsOfUse.title=Indique la façon dont ces données peuvent être utilisées une fois téléchargées.
-file.dataFilesTab.terms.list.termsOfUse.termsOfUse.description=If you are unable to use CC0 for datasets you are able to set custom terms of use. Here is an example of a <a href="https://dataverse.org/best-practices/sample-dua" title="Sample Data Usage Agreement - Dataverse.org" target="_blank">Data Usage Agreement</a> for datasets that have de-identified human subject data.
+file.dataFilesTab.terms.list.termsOfUse.termsOfUse.description=Si vous n'êtes pas en mesure d'utiliser la licence CC0 pour les ensembles de données, vous pouvez établir des conditions d'utilisation personnalisées. Voici un exemple d'une <a href="https://dataverse.org/best-practices/sample-dua" title="Exemple de licence de données - Dataverse.org" target="_blank">licence de données</a> pour des ensembles de données qui comportent des données anonymisées de sujets humains.
 file.dataFilesTab.terms.list.termsOfUse.addInfo=Renseignements supplémentaires
 file.dataFilesTab.terms.list.termsOfUse.addInfo.declaration=Déclaration de confidentialité
 file.dataFilesTab.terms.list.termsOfUse.addInfo.declaration.title=Indique s'il faut signer une déclaration de confidentialité pour avoir accès à une ressource.
 file.dataFilesTab.terms.list.termsOfUse.addInfo.permissions=Permissions spéciales
-file.dataFilesTab.terms.list.termsOfUse.addInfo.permissions.title=Déterminer si des permissions spéciales sont requises pour avoir accès à une ressource (p.ex. si un formulaire est nécessaire et où obtenir le formulaire).
+file.dataFilesTab.terms.list.termsOfUse.addInfo.permissions.title=Déterminer si des permissions spéciales sont requises pour avoir accès à une ressource (p.\u00A0ex. si un formulaire est nécessaire et où obtenir le formulaire).
 file.dataFilesTab.terms.list.termsOfUse.addInfo.restrictions=Restrictions
 file.dataFilesTab.terms.list.termsOfUse.addInfo.restrictions.title=Toute restriction s'appliquant à l'accès à l'ensemble de données et à son utilisation, comme la certification relative à la vie privée ou les restrictions concernant la diffusion, doit être indiquée à cet endroit. Il peut s'agir de restrictions établies selon l'auteur, le producteur ou le diffuseur des données. Si l'accès aux données est limité à une certaine catégorie d'utilisateurs, veuillez le préciser. 
 file.dataFilesTab.terms.list.termsOfUse.addInfo.citationRequirements=Exigences de citation
@@ -1483,12 +1483,12 @@ file.dataFilesTab.terms.list.guestbook.noSelected.admin.tip=Aucun registre des v
 file.dataFilesTab.terms.list.guestbook.inUse.tip=Le registre des visiteurs suivant demandera à un utilisateur de fournir des renseignements supplémentaires au moment du téléchargement d'un fichier.
 file.dataFilesTab.terms.list.guestbook.viewBtn=Prévisualiser le registre des visiteurs
 file.dataFilesTab.terms.list.guestbook.select.tip=Sélectionner un registre des visiteurs afin qu'un utilisateur fournisse des renseignements supplémentaires lorsqu'il télécharge un fichier.
-file.dataFilesTab.terms.list.guestbook.noAvailable.tip=Aucun registre des visiteurs n'est activé dans le {0}. Pour créer un registre des visiteurs, retourner dans le {0}, cliquer sur le bouton «Modifier» et sélectionner «Registres de visiteurs pour l'ensemble de données».
+file.dataFilesTab.terms.list.guestbook.noAvailable.tip=Aucun registre des visiteurs n'est activé dans le {0}. Pour créer un registre des visiteurs, retourner dans le {0}, cliquer sur le bouton «\u00A0Modifier\u00A0» et sélectionner «\u00A0Registres de visiteurs pour l'ensemble de données\u00A0».
 file.dataFilesTab.terms.list.guestbook.clearBtn=Effacer la sélection
 
 file.dataFilesTab.dataAccess=Accès aux données
-file.dataFilesTab.dataAccess.info=Ce fichier de données est accessible via une fenêtre de terminal, en utilisant les commandes ci-dessous. Pour plus d'informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="rsync Download - Dataverse User Guide" target="_blank">téléchargement rsync</a> du guide d'utilisation.
-file.dataFilesTab.dataAccess.info.draft=Les fichiers de données ne sont pas accessibles tant que la version provisoire de l'ensemble de données n'a pas été publiée. Pour plus d'informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="rsync Download - Dataverse User Guide" target="_blank">téléchargement rsync</a> du guide d'utilisation.
+file.dataFilesTab.dataAccess.info=Ce fichier de données est accessible via une fenêtre de terminal, en utilisant les commandes ci-dessous. Pour plus d'informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="Téléchargement rsync - Guide d'utilisation de Dataverse" target="_blank">téléchargement rsync</a> du guide d'utilisation.
+file.dataFilesTab.dataAccess.info.draft=Les fichiers de données ne sont pas accessibles tant que la version provisoire de l'ensemble de données n'a pas été publiée. Pour plus d'informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="Téléchargement rsync - Guide d'utilisation de Dataverse" target="_blank">téléchargement rsync</a> du guide d'utilisation.
 file.dataFilesTab.dataAccess.local.label=Accès local
 file.dataFilesTab.dataAccess.download.label=Accès au téléchargement
 file.dataFilesTab.dataAccess.verify.label=Vérifier les données
@@ -1503,28 +1503,28 @@ file.dataFilesTab.versions.headers.summary=Résumé
 file.dataFilesTab.versions.headers.contributors=Collaborateurs
 file.dataFilesTab.versions.headers.published=Publié
 file.dataFilesTab.versions.viewDiffBtn=Voir les différences
-file.dataFilesTab.versions.citationMetadata=Métadonnées bibliographiques:
+file.dataFilesTab.versions.citationMetadata=Métadonnées bibliographiques\u00A0:
 file.dataFilesTab.versions.added=Ajouté
 file.dataFilesTab.versions.removed=Supprimé
 file.dataFilesTab.versions.changed=Modifié
 file.dataFilesTab.versions.replaced=Remplacé
 file.dataFilesTab.versions.original=Original
 file.dataFilesTab.versions.replacment=Remplacement
-file.dataFilesTab.versions.additionalCitationMetadata=Métadonnées bibliographiques additionnelles:
+file.dataFilesTab.versions.additionalCitationMetadata=Métadonnées bibliographiques additionnelles\u00A0:
 file.dataFilesTab.versions.description.draft=Il s'agit d'une version provisoire.
 file.dataFilesTab.versions.description.deaccessioned=Étant donné que la version précédente a été retirée de la diffusion, aucune note sur les différences n'est disponible pour cette version publiée.
 file.dataFilesTab.versions.description.firstPublished=Il s'agit de la première version publiée.
-file.dataFilesTab.versions.description.deaccessionedReason=Raison du retrait:
-file.dataFilesTab.versions.description.beAccessedAt=L'ensemble de données peut maintenant être consulté à:
+file.dataFilesTab.versions.description.deaccessionedReason=Raison du retrait\u00A0:
+file.dataFilesTab.versions.description.beAccessedAt=L'ensemble de données peut maintenant être consulté à\u00A0:
 file.dataFilesTab.versions.viewDetails.btn=Voir les renseignements
-file.dataFilesTab.versions.widget.viewMoreInfo=Pour afficher plus d'informations sur les versions de cet ensemble de données et pour le modifier s'il s'agit de votre ensemble de données, consultez la <a href="/dataset.xhtml?persistentId = {0}" title="{1}" target="_blank"> version complète de cet ensemble</a> à  {2}.
+file.dataFilesTab.versions.widget.viewMoreInfo=Pour afficher plus d'informations sur les versions de cet ensemble de données et pour le modifier s'il s'agit de votre ensemble de données, consultez la <a href="/dataset.xhtml?persistentId={0}" title="{1}" target="_blank">version complète de cet ensemble</a> à  {2}.
 file.deleteDialog.tip=Êtes-vous sûr(e) de vouloir supprimer cet ensemble de données? Vous ne pourrez pas annuler la suppression.
 file.deleteDialog.header=Supprimer l'ensemble de données
 file.deleteDraftDialog.tip=Êtes-vous sûr(e) de vouloir supprimer cette version provisoire? Vous ne pourrez pas annuler la suppression de cette version. 
 file.deleteDraftDialog.header=Supprimer la version provisoire
-file.deleteFileDialog.tip=Le ou les fichiers seront supprimés dès que vous cliquerez sur le bouton «Enregistrer les modifications» au bas de cette page.
-file.deleteFileDialog.immediate=Le fichier sera supprimé une fois que vous aurez cliqué sur le bouton « Supprimer ». 
-file.deleteFileDialog.multiple.immediate=Le ou les fichiers seront supprimés lorsque vous aurez cliqué sur le bouton « Supprimer ».
+file.deleteFileDialog.tip=Le ou les fichiers seront supprimés dès que vous cliquerez sur le bouton «\u00A0Enregistrer les modifications\u00A0» au bas de cette page.
+file.deleteFileDialog.immediate=Le fichier sera supprimé une fois que vous aurez cliqué sur le bouton «\u00A0Supprimer\u00A0». 
+file.deleteFileDialog.multiple.immediate=Le ou les fichiers seront supprimés lorsque vous aurez cliqué sur le bouton «\u00A0Supprimer\u00A0».
 file.deleteFileDialog.header=Supprimer les fichiers
 file.deleteFileDialog.failed.tip=Les fichiers ne seront pas supprimés des versions de l'ensemble de données publiées précédemment.
 file.deaccessionDialog.tip=Si vous retirez de la diffusion un ensemble de données, le public ne pourra plus le consulter.
@@ -1540,7 +1540,7 @@ file.deaccessionDialog.reason.selectItem.notValid=Ensemble de données non valide
 file.deaccessionDialog.reason.selectItem.other=Autre (Veuillez indiquer la raison dans l'espace fourni ci-dessous.)
 file.deaccessionDialog.enterInfo=Veuillez entrer des renseignements supplémentaires sur la raison du retrait.
 file.deaccessionDialog.leaveURL=S'il y a lieu, veuillez indiquer une adresse URL où cet ensemble de données peut être consulté après son retrait.
-file.deaccessionDialog.leaveURL.watermark=Site facultatif pour l'ensemble de données, http://...
+file.deaccessionDialog.leaveURL.watermark=Site facultatif pour l'ensemble de données, http://\u2026
 file.deaccessionDialog.deaccession.tip=Êtes-vous sûr(e) de vouloir procéder au retrait? La ou les versions sélectionnées ne pourront plus être consultées par le public.
 file.deaccessionDialog.deaccessionDataset.tip=Êtes-vous sûr(e) de vouloir retiré cet ensemble de données? Le public ne pourra plus le consulter.
 file.deaccessionDialog.dialog.selectVersion.tip=Veuillez sélectionner la ou les versions à retirer de la diffusion.
@@ -1563,21 +1563,21 @@ file.viewDiffDialog.fileType=Type
 file.viewDiffDialog.fileSize=Taille
 file.viewDiffDialog.category=Libellés
 file.viewDiffDialog.description=Description
-file.viewDiffDialog.provDescription=Provenance Description
+file.viewDiffDialog.provDescription=Description de la provenance
 file.viewDiffDialog.fileReplaced=Fichier remplacé
 file.viewDiffDialog.filesReplaced=Fichier(s) remplacé(s)
 file.viewDiffDialog.files.header=Fichiers
-file.viewDiffDialog.msg.draftFound=&#160;Ceci est la version provisoire.
+file.viewDiffDialog.msg.draftFound=\u00A0Ceci est la version provisoire.
 file.viewDiffDialog.msg.draftNotFound=La version provisoire n'a pas été trouvée.
-file.viewDiffDialog.msg.versionFound=&#160;Ceci est la version "{0}".
-file.viewDiffDialog.msg.versionNotFound=La version "{0}" n'a pas été trouvée.
-file.metadataTip=Conseil sur les métadonnées: après avoir ajouté l'ensemble de données, cliquer sur le bouton «Modifier l'ensemble de données» pour ajouter plus de métadonnées.
+file.viewDiffDialog.msg.versionFound=\u00A0Ceci est la version «\u00A0{0}\u00A0».
+file.viewDiffDialog.msg.versionNotFound=La version «\u00A0{0}\u00A0» n'a pas été trouvée.
+file.metadataTip=Conseil sur les métadonnées\u00A0: après avoir ajouté l'ensemble de données, cliquer sur le bouton «\u00A0Modifier l'ensemble de données\u00A0» pour ajouter plus de métadonnées.
 file.addBtn=Sauvegarder l'ensemble de données
 file.dataset.allFiles=Tous les fichiers de cet ensemble de données
 file.downloadDialog.header=Télécharger le fichier
 file.downloadDialog.tip=Veuillez confirmer ou remplir l'information requise ci-dessous afin de télécharger les fichiers de cet ensemble de données.
 file.requestAccessTermsDialog.tip=Veuillez confirmer et/ou compléter les informations nécessaires ci-dessous afin de demander l'accès aux fichiers de cet ensemble de données.
-file.search.placeholder=Chercher dans cet ensemble de données...
+file.search.placeholder=Chercher dans cet ensemble de données\u2026
 file.results.btn.sort=Trier
 file.results.btn.sort.option.nameAZ=Nom (A-Z)
 file.results.btn.sort.option.nameZA=Nom (A-Z)
@@ -1585,10 +1585,10 @@ file.results.btn.sort.option.newest=Plus récent
 file.results.btn.sort.option.oldest=Plus ancien
 file.results.btn.sort.option.size=Taille
 file.results.btn.sort.option.type=Catégorie
-file.compute.fileAccessDenied=This file is restricted and you may not compute on it because you have not been granted access.
+file.compute.fileAccessDenied=Ce fichier est à accès restreint et vous ne pouvez y effectuer un calcul puisque vous ne bénéficiez pas des autorisations nécessaires.
 file.configure.Button=Configurer
 file.configure.launchMessage.details=Veuillez actualiser cette page une fois que vous avez configuré votre
- # dataset-widgets.xhtml
+# dataset-widgets.xhtml=
 dataset.widgets.title=Vignette de l'ensemble de données + Widgets
 dataset.widgets.notPublished.why.header=Pourquoi faire appel aux widgets?
 dataset.widgets.notPublished.why.reason1=Augmente la visibilité de vos données en vous permettant d'intégrer votre dataverse et les ensembles de données dans votre site web personnel ou de projet.
@@ -1596,16 +1596,16 @@ dataset.widgets.notPublished.why.reason2=Permet aux autres de parcourir votre da
 dataset.widgets.notPublished.how.header=Comment utiliser les widgets
 dataset.widgets.notPublished.how.tip1=Pour pouvoir utiliser des widgets, votre dataverse et vos ensembles de données doivent être publiés.
 dataset.widgets.notPublished.how.tip2=Suite à la publication, le code sera disponible sur cette page pour que vous puissiez le copier et l'ajouter à votre site web personnel ou de projet.
-dataset.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l'ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title="Adding Widgets to an OpenScholar Website - Dataverse User Guide" target="_blank">ici</a>.
-dataset.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Theme + Widgets - Dataverse User Guide" target="_blank">thème et widgets</a> du guide d'utilisation.
+dataset.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l'ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title="Ajouts de widgets Dataverse dans un site web OpenScholar - Guide d'utilisation de Dataverse" target="_blank">ici</a>.
+dataset.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets - Guide d'utilisation de Dataverse" target="_blank">thème et widgets</a> du guide d'utilisation.
 dataset.widgets.editAdvanced=Modifier les options avancées
-dataset.widgets.editAdvanced.tip=<strong>Options avancées</strong> &#150; Options supplémentaires pour configurer votre widget sur votre site personnel ou de projet.
-dataset.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Theme + Widgets - Dataverse User Guide" target="_blank">Thème et widgets</a> du guide d'utilisation.
+dataset.widgets.editAdvanced.tip=<strong>Options avancées</strong> – Options supplémentaires pour configurer votre widget sur votre site personnel ou de projet.
+dataset.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets - Guide d'utilisation de Dataverse" target="_blank">Thème et widgets</a> du guide d'utilisation.
 dataset.widgets.citation.txt=Citation de l'ensemble de données
 dataset.widgets.citation.tip=Ajoutez la référence de votre ensemble de données à votre site personnel ou de projet.
 dataset.widgets.datasetFull.txt=Ensemble de données
 dataset.widgets.datasetFull.tip=Permet aux visiteurs de votre site web d'être en mesure d'afficher vos ensembles de données, de télécharger des fichiers, etc.
-dataset.widgets.advanced.popup.header=Widgets: Options avancées
+dataset.widgets.advanced.popup.header=Widgets\u00A0: Options avancées
 dataset.widgets.advanced.prompt=Expédier vers votre site web personnel l'URL pérenne de la référence bibliographique de l'ensemble de données.
 dataset.widgets.advanced.url.label=URL de votre site web personnel
 dataset.widgets.advanced.url.watermark=http://www.exemple.com/nom-de-la-page
@@ -1638,10 +1638,10 @@ file.share.fileShare.tip=Partager ce fichier sur vos médias sociaux préférés.
 file.share.fileShare.shareText=Afficher ce fichier.
 file.title.label=Titre
 file.citation.label=Référence bibliographique
-file.citation.notice=This file is part of "{0}". If you use this file, please cite the dataset:
-file.cite.downloadBtn=Cite Dataset
-file.pid.label=File Persistent ID:
-file.unf.lable= File UNF:
+file.citation.notice=Ce fichier fait partie de «\u00A0{0}\u00A0». Si vous utilisez ce fichier, prière de citer l'ensemble de données\u00A0:
+file.cite.downloadBtn=Citer l'ensemble de données
+file.pid.label=Identifiant permanent du fichier\u00A0:
+file.unf.lable= Fichier UNF\u00A0:
 file.general.metadata.label=Métadonnées générales
 file.description.label=Description
 file.tags.label=Libellés
@@ -1651,7 +1651,7 @@ file.DatasetVersion=Version
 file.metadataTab.fileMetadata.header=Métadonnées du fichier
 file.metadataTab.fileMetadata.persistentid.label=Identifiant pérenne du fichier
 file.metadataTab.fileMetadata.downloadUrl.label=URL de téléchargement
-file.metadataTab.fileMetadata.unf.label=File UNF
+file.metadataTab.fileMetadata.unf.label=Fichier UNF
 file.metadataTab.fileMetadata.size.label=Taille
 file.metadataTab.fileMetadata.type.label=Catégorie
 file.metadataTab.fileMetadata.description.label=Description
@@ -1677,8 +1677,8 @@ file.versionDifferences.fileGroupTitle=Fichier
 
 # File Ingest
 ingest.csv.invalidHeader=Ligne d'en-tête non valide. L'une des cellules est vide.
-ingest.csv.lineMismatch=Incompatibilité entre les décomptes de ligne des première et dernière passes!, {0} trouvée(s) au premier passage, mais {1} trouvée(s) au deuxième.
-ingest.csv.recordMismatch=Incompatibilité de lecture, ligne {0} du fichier de données: {1} valeur(s) délimitée(s) attendue(s), {2} trouvée(s).
+ingest.csv.lineMismatch=Incompatibilité entre les décomptes de lignes des premier et dernier passages!, {0} ligne(s) trouvée(s) au premier passage, mais {1} ligne(s) trouvée(s) au deuxième.
+ingest.csv.recordMismatch=Incompatibilité de lecture, ligne {0} du fichier de données\u0020: {1} valeur(s) délimitée(s) attendue(s), {2} trouvée(s).
 ingest.csv.nullStream=Le flux ne peut pas être nul.
 
 # editdatafile.xhtml
@@ -1700,21 +1700,21 @@ file.addreplace.error.dataset_is_null=L'ensemble de données ne peut être nul.
 file.addreplace.error.dataset_id_is_null=L'identifiant de l'ensemble de données ne peut être nul.
 find.dataset.error.dataset_id_is_null=L'accès à un ensemble de données basé sur un identifiant pérenne requiert qu'un paramètre de requête {0} soit présent.
 find.dataset.error.dataset.not.found.persistentId=L'ensemble de données basé sur l'identifiant pérenne {0} est introuvable.
-find.datasetlinking.error.not.found.ids=Dataset linking dataverse with dataset ID {0} and dataset linking dataverse ID {1} not found.
-find.datasetlinking.error.not.found.bad.ids=Bad dataset ID number: {0} or dataset linking dataverse ID number: {1}.
-find.dataverselinking.error.not.found.ids=Dataverse linking dataverse with dataverse ID {0} and dataverse linking dataverse ID {1} not found.
-find.dataverselinking.error.not.found.bad.ids=Bad dataverse ID number: {0} or dataverse linking dataverse ID number: {1}.
-find.datafile.error.datafile.not.found.id=File with ID {0} not found.
-find.datafile.error.datafile.not.found.bad.id=Bad file ID number: {0}.
-find.datafile.error.dataset.not.found.persistentId=Datafile with Persistent ID {0} not found.
-file.addreplace.error.dataset_id_not_found=Aucun ensemble de données n'a été trouvé pour l'identifiant:
+find.datasetlinking.error.not.found.ids=L'ensemble de données du dataverse lié ayant l'identifiant d'ensemble de données {0} et l'ensemble de données du dataverse lié ayant l'identifiant {1} sont introuvables.
+find.datasetlinking.error.not.found.bad.ids=Identifiant de l'ensemble de données erroné\u00A0: {0} ou ensemble de données du dataverse lié ayant l'identifiant\u00A0: {1}.
+find.dataverselinking.error.not.found.ids=Le dataverse du dataverse lié ayant l'identifiant de dataverse {0} et le dataverse du dataverse lié ayant l'identifiant {1} sont introuvables.
+find.dataverselinking.error.not.found.bad.ids=Identifiant du dataverse erroné\u00A0: {0} ou ensemble de données du dataverse lié ayant l'identifiant\u00A0: {1}.
+find.datafile.error.datafile.not.found.id=Le fichier dont l'identifiant est {0} est introuvable.
+find.datafile.error.datafile.not.found.bad.id=Identifiant de fichier erroné\u00A0: {0}.
+find.datafile.error.dataset.not.found.persistentId=Le fichier de données ayant l'identifiant pérenne {0} est introuvable.
+file.addreplace.error.dataset_id_not_found=Aucun ensemble de données n'a été trouvé pour l'identifiant\u00A0:
 file.addreplace.error.no_edit_dataset_permission=Vous n'avez pas la permission de modifier cet ensemble de données.
 file.addreplace.error.filename_undetermined=Le nom du fichier ne peut être établi.
 file.addreplace.error.file_content_type_undetermined=Le type de contenu du fichier ne peut être établi.
 file.addreplace.error.file_upload_failed=Le téléversement du fichier a échoué.
 file.addreplace.error.duplicate_file=Ce fichier existe déjà dans l'ensemble de données. 
 file.addreplace.error.existing_file_to_replace_id_is_null=L'identifiant du fichier existant à remplacer doit être fourni.
-file.addreplace.error.existing_file_to_replace_not_found_by_id=Fichier de remplacement non trouvé. Aucun fichier n'a été trouvé pour l'identifiant: {0}
+file.addreplace.error.existing_file_to_replace_not_found_by_id=Fichier de remplacement non trouvé. Aucun fichier n'a été trouvé pour l'identifiant\u00A0: {0}
 file.addreplace.error.existing_file_to_replace_is_null=Le fichier à remplacer ne peut être nul.
 file.addreplace.error.existing_file_to_replace_not_in_dataset=Le fichier à remplacer n'appartient pas à cet ensemble de données.
 file.addreplace.error.existing_file_not_in_latest_published_version=Vous ne pouvez pas remplacer un fichier qui n'est pas dans le dernier ensemble de données publié. (Le fichier est non publié ou a été supprimé d'une version précédente.)
@@ -1733,7 +1733,7 @@ file.addreplace.error.phase2_called_early_no_new_files=Une erreur s'est produite
 file.addreplace.success.add=Le fichier a bien été ajouté!
 file.addreplace.success.replace=Le fichier a bien été remplacé!
 file.addreplace.error.auth=La clé API n'est pas valide.
-file.addreplace.error.invalid_datafile_tag=Libellé de données tabulaires non valide: 
+file.addreplace.error.invalid_datafile_tag=Libellé de données tabulaires non valide\u00A0: 
 
 # 500.xhtml
 error.500.page.title=500 - Erreur interne du serveur
@@ -1747,7 +1747,7 @@ error.404.message=<strong>Page non trouvée</strong> - La page que vous cherchez 
 error.403.page.title=403 - Non autorisé
 error.403.message=<strong>Non autorisé</strong> - Vous n'êtes pas autorisé à voir cette page.
 
-# general error - support message
+# general error - support message=
 error.support.message=Si vous pensez qu'il s'agit d'une erreur, veuillez contacter {0} pour obtenir de l'aide.
 
 # citation-frame.xhtml
@@ -1759,87 +1759,87 @@ citationFrame.banner.countdownMessage.seconds=secondes
 
 # Friendly AuthenticationProvider names
 authenticationProvider.name.builtin=Dataverse
-authenticationProvider.name.null=(provider is unknown)
+authenticationProvider.name.null=(fournisseur inconnu)
 authenticationProvider.name.github=GitHub
 authenticationProvider.name.google=Google
 authenticationProvider.name.orcid=ORCiD
-authenticationProvider.name.orcid-sandbox=ORCiD Sandbox
+authenticationProvider.name.orcid-sandbox=Bac à sable ORCiD
 authenticationProvider.name.shib=Shibboleth
-ingest.csv.invalidHeader=Invalid header row. One of the cells is empty.
-ingest.csv.lineMismatch=Mismatch between line counts in first and final passes!, {0} found on first pass, but {1} found on second.
-ingest.csv.recordMismatch=Reading mismatch, line {0} of the Data file: {1} delimited values expected, {2} found.
-ingest.csv.nullStream=Stream can't be null.
-citationFrame.banner.countdownMessage.seconds=seconds
+ingest.csv.invalidHeader=Ligne d'en-tête non valide. L'une des cellules est vide.
+ingest.csv.lineMismatch=Incompatibilité entre les décomptes de ligne des premières et derniers tours!, {0} trouvé au premier tour, mais {1} trouvé au deuxième.
+ingest.csv.recordMismatch=Incompatibilité de lecture, ligne {0} du fichier de données\u00A0: {1} valeurs délimitées attendues, {2} trouvées.
+ingest.csv.nullStream=Le flux ne peut être nul.
+citationFrame.banner.countdownMessage.seconds=secondes
 
 #dataset.xhtml #editFilesFragment.xhtml
-dataset.access.accessHeader=File Restrictions
+dataset.access.accessHeader=Restrictions d'accès au fichier
 
 #dataserFieldForEditFragment.xhtml
-dataset.AddReplication=Add "Replication Data for" to Title
-dataset.replicationDataFor=Replication Data for:
+dataset.AddReplication=Ajouter «\u00A0Données de réplication pour\u00A0» au titre
+dataset.replicationDataFor=Données de réplication pour\u00A0:
 
 
 #mydata_fragment.xhtml
-mydataFragment.infoAccess=Here are all the dataverses, datasets, and files you have access to. You can filter through them by publication status and roles.
-mydataFragment.moreResults=View More Results
-mydataFragment.publicationStatus=Publication Status
-mydataFragment.roles=Roles
-mydataFragment.resultsByUserName=Results by Username
-mydataFragment.search=Search my data...
+mydataFragment.infoAccess=Tous les dataverses, ensembles de données et fichiers auxquels vous avez accès sont listés ici. Vous pouvez les filtrer par statut de publication et rôles.
+mydataFragment.moreResults=Voir plus de résultats
+mydataFragment.publicationStatus=Statut de publication
+mydataFragment.roles=Rôles
+mydataFragment.resultsByUserName=Résultats par nom d'utilisateur
+mydataFragment.search=Rechercher mes données\u2026
 
 file.provenance=Provenance
 file.editProvenanceDialog=Provenance
-file.editProvenanceDialog.tip=Provenance is a record of the origin of your data file and any transformations it has been through. Upload a JSON file from a provenance capture tool to generate a graph of your data''s provenance. For more information, please refer to our <a href="{0}/{1}/user/" title="Dataverse User Guide" target="_blank">User Guide</a>.
-file.editProvenanceDialog.uploadSuccess=Upload complete
-file.editProvenanceDialog.uploadError=An error occurred during upload and parsing of your provenance file.
-file.editProvenanceDialog.noEntitiesError=The uploaded provenance file does not contain any entities that can be related to your Data File. 
-file.editProvenanceDialog.bundleFile=Provenance File
-file.editProvenanceDialog.bundleFile.instructions=File must be JSON format and follow W3C standards.
-file.editProvenanceDialog.bundleFile.alreadyPublished=This Provenance File has been published and cannot be replaced or removed.
-file.editProvenanceDialog.bundleEntity=Data File Entity
-file.editProvenanceDialog.bundleEntity.placeholder=Connect entity...
-file.editProvenanceDialog.bundleEntity.requiredValidation=Value is required.
-file.editProvenanceDialog.bundleEntity.tip=Select the entity in your provenance file which represents your data file.
-file.editProvenanceDialog.bundleEntity.nameHeader=Name
+file.editProvenanceDialog.tip=Par provenance on entend l'enregistrement de l'origine de votre fichier de données ainsi que des transformations qu'il a subies. Télécharger un fichier JSON à partir d'un outil de capture de provenance pour générer un graphique de la provenance de vos données. Pour plus d'informations, consultez notre <a href="{0}/{1}/user/" title="Guide d'utilisation de Dataverse" target="_blank">Guide d'utilisation</a>.
+file.editProvenanceDialog.uploadSuccess=Téléversement complété.
+file.editProvenanceDialog.uploadError=Une erreur s'est produite lors du téléversement et de l'analyse de votre fichier de provenance.
+file.editProvenanceDialog.noEntitiesError=Le fichier de provenance téléversé ne contient aucune entité pouvant être liée à votre fichier de données. 
+file.editProvenanceDialog.bundleFile=Fichier de provenance
+file.editProvenanceDialog.bundleFile.instructions=Le fichier doit être au format JSON et être conforme aux normes du W3C.
+file.editProvenanceDialog.bundleFile.alreadyPublished=Ce fichier de provenance a été publié et ne peut pas être remplacé ou supprimé.
+file.editProvenanceDialog.bundleEntity=Entité de fichier de données
+file.editProvenanceDialog.bundleEntity.placeholder=Connexion à l'entité\u2026
+file.editProvenanceDialog.bundleEntity.requiredValidation=Une valeur est requise.
+file.editProvenanceDialog.bundleEntity.tip=Sélectionnez l'entité dans votre fichier de provenance qui représente votre fichier de données.
+file.editProvenanceDialog.bundleEntity.nameHeader=Nom
 file.editProvenanceDialog.bundleEntity.typeHeader=Type
-file.editProvenanceDialog.bundleEntity.entityHeader=Entity
-file.editProvenanceDialog.selectToAddBtn=Select File
-file.editProvenanceDialog.description.tip=You may also add information documenting the history of your data file, including how it was created, how it has changed, and who has worked with it.
-file.editProvenanceDialog.description=Provenance Description
-file.editProvenanceDialog.description.placeholder=Add provenance description...
+file.editProvenanceDialog.bundleEntity.entityHeader=Entité
+file.editProvenanceDialog.selectToAddBtn=Choisir le fichier
+file.editProvenanceDialog.description.tip=Vous pouvez également ajouter des informations documentant l'historique de votre fichier de données, y compris la manière dont il a été créé, comment il a été modifié et qui y a travaillé.
+file.editProvenanceDialog.description=Description de la provenance
+file.editProvenanceDialog.description.placeholder=Ajouter la description de la provenance\u2026
 file.confirmProvenanceDialog=Provenance
-file.confirmProvenanceDialog.tip1=Once you publish this dataset, your provenance file can not be edited or replaced.
-file.confirmProvenanceDialog.tip2=Select "Cancel" to return the previous page, where you can preview your provenance file to confirm it is correct.
-file.metadataTab.provenance.header=File Provenance
-file.metadataTab.provenance.body=File Provenance information coming in a later release...
-file.metadataTab.provenance.error=Due to an internal error, your provenance information was not correctly saved.
-file.metadataTab.provenance.message=Your provenance information has been received. Please click Save Changes below to ensure all data is added to your dataset.
+file.confirmProvenanceDialog.tip1=Une fois que vous avez publié cet ensemble de données, votre fichier de provenance ne peut être modifié ou remplacé.
+file.confirmProvenanceDialog.tip2=Sélectionnez «\u00A0Annuler\u00A0» afin de retourner à la page précédente, où vous pouvez prévisualiser votre fichier de provenance pour confirmer qu'il est conforme.
+file.metadataTab.provenance.header=Fichier de provenance
+file.metadataTab.provenance.body=Informations sur le fichier de provenance à venir dans une version ultérieure\u2026
+file.metadataTab.provenance.error=En raison d'une erreur interne, vos informations de provenance n'ont pas été enregistrées correctement
+file.metadataTab.provenance.message=Vos informations de provenance ont bien été reçues. Veuillez cliquer sur Enregistrer les modifications ci-dessous pour vous assurer que toutes les données soient ajoutées à votre ensemble de données.
 
-file.provConfirm.unpublished.json=Your Provenance File will become permanent upon publishing your dataset. Please preview to confirm before publishing. 
-file.provConfirm.published.json=Your Provenance File will become permanent once you click Save Changes. Please preview to confirm before you Save Changes.
-file.provConfirm.freeform=Your Provenance Description is not permanent; it can be updated at any time.
-file.provConfirm.empty=No changes have been made.
+file.provConfirm.unpublished.json=Votre fichier de provenance deviendra permanent une fois votre ensemble de données publié. Veuillez prévisualiser pour confirmer avant de publier. 
+file.provConfirm.published.json=Votre fichier de provenance deviendra permanent une fois que vous aurez cliqué sur Enregistrer les modifications. Veuillez prévisualiser pour confirmer avant d'enregistrer les modifications.
+file.provConfirm.freeform=Votre description de provenance n'est pas permanente et peut être mise à jour à tout moment.
+file.provConfirm.empty=Aucun changement n'a été fait.
 
-file.provAlert.published.json=Your Provenance File changes have been saved to the Dataset. 
-file.provAlert.unpublished.json=Your Provenance File changes will be saved to this version of the Dataset once you click on the Save Changes button. 
-file.provAlert.freeform=Your Provenance Description changes will be saved to this version of the Dataset once you click on the Save Changes button. 
-file.provAlert.filePage.published.json=Your Provenance File changes have been saved to the Dataset. 
-file.provAlert.filePage.unpublished.json=Your Provenance File changes have been saved to this version of the Dataset. 
-file.provAlert.filePage.freeform=Your Provenance Description changes have been saved to this version of the Dataset. 
+file.provAlert.published.json=Vos modifications au fichier de provenance ont été enregistrées dans l'ensemble de données. 
+file.provAlert.unpublished.json=Vos modifications au fichier de provenance seront enregistrées dans cette version de l'ensemble de données une fois que vous aurez cliqué sur le bouton Enregistrer les modifications. 
+file.provAlert.freeform=Vos modifications au fichier de provenance seront enregistrées dans cette version de l'ensemble de données une fois que vous aurez cliqué sur le bouton Enregistrer les modifications. 
+file.provAlert.filePage.published.json=Vos modifications au fichier de provenance ont été enregistrées dans l'ensemble de données. 
+file.provAlert.filePage.unpublished.json=Vos modifications au fichier de provenance ont été enregistrées dans cette version de l'ensemble de données. 
+file.provAlert.filePage.freeform=Vos modifications au fichier de provenance ont été enregistrées dans cette version de l'ensemble de données.  
 
-api.prov.provJsonSaved=PROV-JSON provenance data saved for Data File:
-api.prov.provJsonDeleted=PROV-JSON deleted for the selected Data File.
+api.prov.provJsonSaved=Données de provenance PROV-JSON sauvegardées pour le fichier de données\u00A0: 
+api.prov.provJsonDeleted=PROV-JSON supprimé pour le fichier de données sélectionné.
 
-api.prov.error.provDisabled=This functionality has been administratively disabled.
-api.prov.error.badDataFileId=Invalid DataFile ID.
-api.prov.error.jsonUpdateNotAllowed=PROV-JSON cannot be updated for a published file that already has PROV-JSON.
-api.prov.error.entityMismatch=Entity name provided does not match any entities parsed from the uploaded PROV-JSON.
-api.prov.error.jsonDeleteNotAllowed=PROV-JSON cannot be deleted for a published file.
-api.prov.error.jsonNoContent=No provenance json available for this file.
-api.prov.error.freeformInvalidJson=A valid JSON object could not be found.
-api.prov.error.freeformMissingJsonKey=The JSON object you send must have a key called 'text'.
-api.prov.error.freeformNoText=No provenance free form text available for this file.
-api.prov.error.noDataFileFound=Could not find a file based on ID.
+api.prov.error.provDisabled=Cette fonctionnalité a été désactivée administrativement.
+api.prov.error.badDataFileId=Identifiant de fichier de données incorrect.
+api.prov.error.jsonUpdateNotAllowed=PROV-JSON ne peut être mis à jour pour un fichier publié ayant déjà un PROV-JSON.
+api.prov.error.entityMismatch=Le nom d'entité fourni ne correspond à aucune entité analysée à partir du PROV-JSON téléversé.
+api.prov.error.jsonDeleteNotAllowed=PROV-JSON ne peut être supprimé pour un fichier publié.
+api.prov.error.jsonNoContent=Aucune provenance JSON disponible pour ce fichier.
+api.prov.error.freeformInvalidJson=Un objet JSON valide n'a pu être trouvé.
+api.prov.error.freeformMissingJsonKey=L'objet JSON que vous envoyez doit avoir une clé appelée «\u00A0texte\u00A0».
+api.prov.error.freeformNoText=Aucune provenance en format texte libre disponible pour ce fichier.
+api.prov.error.noDataFileFound=Impossible de trouver un fichier basé sur l'identifiant.
 
 #Permission.java
 permission.addDataverseDataverse=Ajouter un dataverse à l'intérieur d'un autre dataverse
@@ -1859,7 +1859,7 @@ permission.addDatasetDataverse=Ajouter un ensemble de données à un dataverse
 #DataverseUserPage.java
 userPage.informationUpdated=L'information associée à votre compte a bien été mise à jour.
 userPage.passwordChanged=Votre mot de passe a bien été modifié.
-confirmEmail.changed=Your email address has changed and must be re-verified. Please check your inbox at {0} and follow the link we've sent. \n\nAlso, please note that the link will only work for the next {1} before it has expired.
+confirmEmail.changed=Votre adresse courriel a changé et doit être re-vérifiée. Veuillez vérifier votre boîte de courriel entrant à {0} et suivre le lien que nous avons envoyé. \n\nVeuillez également noter que le lien ne fonctionnera que pour le prochain {1} avant son expiration.
 
 #Dataset.java
 dataset.category.documentation=Documentation
@@ -1867,61 +1867,61 @@ dataset.category.data=Données
 dataset.category.code=Code
 
 #DatasetVersionDifference.java
-dataset.version.file.added=Fichiers (Ajouté(s): {0}
-dataset.version.file.removed=Fichiers (Supprimé(s): {0}
-dataset.version.file.removed2=; Supprimé(s): {0}
-dataset.version.file.replaced=Fichiers (Remplacé(s): {0}
-dataset.version.file.replaced2=; Remplacé(s): {0}
-dataset.version.file.changed=Fichiers (Métadonnées modifiées: {0}
-dataset.version.file.changed2=; Métadonnées modifiées: {0}
+dataset.version.file.added=Fichiers (Ajouté(s)\u00A0: {0}
+dataset.version.file.removed=Fichiers (Supprimé(s)\u00A0: {0}
+dataset.version.file.removed2=; Supprimé(s)\u00A0: {0}
+dataset.version.file.replaced=Fichiers (Remplacé(s)\u00A0: {0}
+dataset.version.file.replaced2=; Remplacé(s)\u00A0: {0}
+dataset.version.file.changed=Fichiers (Métadonnées modifiées\u00A0: {0}
+dataset.version.file.changed2=; Métadonnées modifiées\u00A0: {0}
 
 #DataversePage.java
 dataverse.item.required=Obligatoire
 dataverse.item.optional=Facultatif
 dataverse.item.hidden=Information cachée
-dataverse.edit.msg=Edit Dataverse
-dataverse.edit.detailmsg= - Edit your dataverse and click Save. Asterisks indicate required fields.
-dataverse.feature.update=The featured dataverses for this dataverse have been updated.
-dataverse.link.select=You must select a linking dataverse.
-dataverse.link.user=Only authenticated users can link a dataverse.
-dataverse.link.error=Unable to link {0} to {1}. An internal error occurred.
-dataverse.search.user=Only authenticated users can save a search.
+dataverse.edit.msg=Modifier le dataverse
+dataverse.edit.detailmsg= - Modifier votre dataverse puis cliquer sur Enregistrer. Les astérisques indiquent les champs obligatoires
+dataverse.feature.update=Les dataverses en vedette pour ce dataverse ont été mis à jour.
+dataverse.link.select=Vous devez sélectionner un dataverse lié.
+dataverse.link.user=Seuls les utilisateurs authentifiés peuvent lier un dataverse.
+dataverse.link.error=Impossible de lier {0} à {1}. Une erreur interne est survenue.
+dataverse.search.user=Seuls les utilisateurs authentifiés peuvent enregistrer une recherche.
 dataverse.alias=alias
-dataverse.alias.taken=This Alias is already taken.
+dataverse.alias.taken=Cet alias est déjà pris.
 
 #editDatafilesPage.java
-dataset.save.fail=Dataset Save Failed
-dataset.files.exist=The following files already exist in the dataset:
-dataset.file.exist=The following file already exists in the dataset:
-dataset.files.duplicate=The following files are duplicates of (an) already uploaded file(s):
-dataset.file.duplicate=The following file is a duplicate of an already uploaded file:
-dataset.file.skip=(skipping)
-dataset.file.upload=Succesful {0} is uploaded.
-dataset.file.uploadFailure=upload failure
-dataset.file.uploadFailure.detailmsg=the file {0} failed to upload!
-dataset.file.uploadWarning=upload warning
-dataset.file.uploadWorked=upload worked
+dataset.save.fail=Échec de l'enregistrement de l'ensemble de données
+dataset.files.exist=Les fichiers suivants font déjà partie de l'ensemble de données\u00A0: 
+dataset.file.exist=Le fichier suivant fait déjà partie de l'ensemble de données\u00A0: 
+dataset.files.duplicate=Les fichiers suivants sont des doublons d'un (de) fichier(s) déjà téléversé(s)\u00A0:
+dataset.file.duplicate=Le fichier suivant est un doublon d'un fichier déjà téléversé\u00A0:
+dataset.file.skip=(ignoré)
+dataset.file.upload={0} est téléversé avec succès.
+dataset.file.uploadFailure=Échec de téléversement
+dataset.file.uploadFailure.detailmsg=Le fichier {0} n'a pu être importé!
+dataset.file.uploadWarning=Avertissement de téléversement
+dataset.file.uploadWorked=Le téléversement a fonctionné
 
 #EmailValidator.java
-email.invalid=is not a valid email address.
+email.invalid=n'est pas une adresse courriel valide.
 
 #HarvestingClientsPage.java
-harvest.start.error=Sorry, harvest could not be started for the selected harvesting client configuration (unknown server error).
-harvest.delete.error=Selected harvesting client cannot be deleted; unknown exception:
-harvest.create.error=Failed to create a new Harvesting Client configuration: no destination dataverse selected.
-harvest.createCommand.error=Harvesting client creation command failed
-harvest.create.fail=Harvesting client creation failed (reason unknown).
-harvest.update.success=Succesfully updated harvesting client
-harvest.save.failure1=Failed to save harvesting client
-harvest.save.failure2=Failed to save harvesting client (reason unknown).
+harvest.start.error=Désolé, le moissonnage n'a pu être démarré selon la configuration du client de moissonnage sélectionné (erreur de serveur inconnue).
+harvest.delete.error=Le client de moissonnage sélectionné ne peut être supprimé; exception inconnue\u00A0:
+harvest.create.error=Impossible de créer une nouvelle configuration du client de moissonnage\u00A0: aucun dataverse de destination n'est sélectionné. 
+harvest.createCommand.error=Échec de la commande de création du client de moissonnage
+harvest.create.fail=Échec de la création du client de moissonnage (raison inconnue).
+harvest.update.success=Client de moissonnage mis à jour avec succès
+harvest.save.failure1=Échec de la sauvegarde du client de moissonnage 
+harvest.save.failure2=Échec de la sauvegarde du client de moissonnage (raison inconnue).
 
 #HarvestingSetsPage.java
-harvest.oaicreate.fail=Failed to create OAI set
-harvest.oaiupdate.fail=Failed to update OAI set.
-harvest.oaiupdate.success=Succesfully updated OAI set &#34;{0}&#34;.
-harvest.delete.fail=Failed to delete harvesting set; unknown exception: 
-harvest.reexport.fail=Sorry, could not start re-export on selected OAI set (unknown server error).
-harvest.search.failed=Search failed for the query provided. Message from the Dataverse search server:
+harvest.oaicreate.fail=Échec de la création de l'ensemble OAI
+harvest.oaiupdate.fail=Échec de la mise à jour de l'ensemble OAI.
+harvest.oaiupdate.success=Mise à jour de l'ensemble OAI «\u00A0{0}\u00A0» réussie.
+harvest.delete.fail=Échec de la suppression de l'ensemble moissonné; exception inconnue\u00A0: 
+harvest.reexport.fail=Désolé, impossible de démarrer la réexportation sur l'ensemble OAI sélectionné (erreur de serveur inconnue).
+harvest.search.failed=La recherche a échoué pour la requête fournie. Message du serveur de recherche Dataverse\u00A0:
 
 #LoginPage.java
 login.UserName=Veuillez entrer un nom d'utilisateur.
@@ -1932,73 +1932,72 @@ system.app.terms=Il n'y a pas de conditions d'utilisation associées à cette inst
 system.api.terms=Il n'y a pas de conditions d'utilisation des API associées à cette installation de Dataverse. 
 
 #DatasetPage.java
-dataverse.notreleased=DataverseNotReleased
-dataverse.release.authenticatedUsersOnly=Only authenticated users can release a dataverse.
-dataset.registration.failed=Dataset Registration Failed
-dataset.registered=DatasetRegistered
-dataset.registered.msg=Your dataset is now registered.
-dataset.notlinked=DatasetNotLinked
-dataset.notlinked.msg=There was a problem linking this dataset to yours:
+dataverse.notreleased=Dataverse non publié
+dataverse.release.authenticatedUsersOnly=Seuls les utilisateurs authentifiés peuvent publier un dataverse.
+dataset.registration.failed=Échec de l'enregistrement du l'ensemble de données
+dataset.registered=Ensemble de données enregistré
+dataset.registered.msg=Votre ensemble de données est maintenant enregistré.
+dataset.notlinked=Ensemble de données non lié
+dataset.notlinked.msg=Un problème est survenu lors de la liaison de cet ensemble de données avec le vôtre\u00A0:
 
 #ThemeWidgetFragment.java
-theme.validateTagline=Tagline must be at most 140 characters.
-theme.urlValidate=URL validation failed.
-theme.urlValidate.msg=Please provide URL.
-dataverse.save.failed=Dataverse Save Failed -
+theme.validateTagline=Le titre d'appel doit comporter au maximum 140 caractères.
+theme.urlValidate=La validation d'URL a échoué.
+theme.urlValidate.msg=Prière de fournir un URL.
+dataverse.save.failed=Échec de l'enregistrement Dataverse -
 
 #LinkValidator.java
-link.tagline.validate=Please enter a tagline for the website to be hyperlinked with.
+link.tagline.validate=Veuillez entrer un titre d'appel pour le site web qui constituera le texte d'hyperlien.
 
 #TemplatePage.java
-template.save.fail=Template Save Failed
-template.create=Template has been created.
-template.save=Template has been edited and saved.
+template.save.fail=Échec de l'enregistrement du modèle
+template.create=Le modèle a été créé.
+template.save=Le modèle a été modifié et enregistré.
 
 #GuestbookPage.java
-guestbook.save.fail=Guestbook Save Failed
-guestbook.option.msg= - An Option question requires multiple options. Please complete before saving.
-guestbook.create=The guestbook has been created. 
-guestbook.save=The guestbook has been edited and saved.
+guestbook.save.fail=La sauvegarde du registre des visiteurs a échoué.
+guestbook.option.msg= - Une question à choix multiples nécessite plusieurs choix de réponses. Veuillez compléter avant d'enregistrer.
+guestbook.create=Le registre des visiteurs a été créé. 
+guestbook.save=Le registre des visiteurs a été modifié et enregistré.
 
 #Shib.java
-shib.invalidEmailAddress=The SAML assertion contained an invalid email address: &#34;{0}&#34;.
-shib.emailAddress.error=A single valid address could not be found.
-shib.nullerror=The SAML assertion for &#34;{0}&#34; was null. Please contact support.
-dataverse.shib.success=Your Dataverse account is now associated with your institutional account.
-shib.createUser.fail=Couldn't create user.
+shib.invalidEmailAddress=L'assertion SAML contenait une adresse courriel invalide\u00A0: «\u00A0{0}\u00A0».
+shib.emailAddress.error=Une seule adresse valide n'a pu être trouvée.
+shib.nullerror=L'assertion SAML pour «\u00A0{0}\u00A0» était nulle. S'il vous plaît contacter le soutien.
+dataverse.shib.success=Votre compte Dataverse est maintenant associé à votre compte institutionnel.
+shib.createUser.fail=Impossible de créer un utilisateur.
 
 #IngestServiceBean.java
-ingest.failed=ingest failed
+ingest.failed=l'ingestion a échoué
 
 #ManagePermissionsPage.java
-permission.roleWasRemoved={0} role for {1} was removed.
-permission.defaultPermissionDataverseUpdated=The default permissions for this dataverse have been updated.
-permission.roleAssignedToFor={0} role assigned to {1} for {2}.
-permission.roleNotAssignedFor={0} role could NOT be assigned to {1} for {2}.
-permission.updated=updated
-permission.created=created
-permission.roleWas=The role was {0}. To assign it to a user and/or group, click on the Assign Roles to Users/Groups button in the Users/Groups section of this page.
-permission.roleNotSaved=The role was not able to be saved.
-permission.permissionsMissing=Permissions {0} missing.
-permission.CannotAssigntDefaultPermissions=Cannot assign default permissions.
+permission.roleWasRemoved=Le rôle {0} pour {1} a été supprimé.
+permission.defaultPermissionDataverseUpdated=Les autorisations par défaut pour ce dataverse ont été mises à jour.
+permission.roleAssignedToFor=Rôle {0} assigné à {1} pour {2}.
+permission.roleNotAssignedFor=Rôle {0} N'A PU ÊTRE assigné à {1} pour {2}.
+permission.updated=mis à jour
+permission.created=créé
+permission.roleWas=Le rôle était {0}. Pour l'attribuer à un utilisateur et/ou un groupe, cliquer sur le bouton Assigner des rôles aux utilisateurs/groupes dans la section Utilisateurs/Groupes de cette page.
+permission.roleNotSaved=Le rôle n'a pu être sauvegardé.
+permission.permissionsMissing= Les permissions {0} sont manquantes.
+permission.CannotAssigntDefaultPermissions=Impossible d'attribuer des autorisations par défaut.
 
 #ManageFilePermissionsPage.java
-permission.roleNotAbleToBeRemoved=The role assignment was not able to be removed.
-permission.fileAccessGranted=File Access request by {0} was granted.
-permission.fileAccessRejected=File Access request by {0} was rejected.
-permission.roleNotAbleToBeAssigned=The role was not able to be assigned.
+permission.roleNotAbleToBeRemoved=L'attribution de rôle n'a pu être supprimée.
+permission.fileAccessGranted=La demande d'accès au fichier par {0} a été accordée.
+permission.fileAccessRejected=La demande d'accès au fichier par {0} a été refusée.
+permission.roleNotAbleToBeAssigned=Le rôle n'a pu être assigné.
 
 #ManageGroupsPage.java
 dataverse.manageGroups.create.success=Le groupe {0} a bien été créé. Actualiser pour mettre à jour votre page. 
 dataverse.manageGroups.save.success=Le groupe {0} a bien été sauvegardé.
-dataverse.manageGroups.delete=The group has been deleted.
-dataverse.manageGroups.nodelete=The explicit group cannot be deleted.
-dataverse.manageGroups.create.fail=Group Creation failed.
-dataverse.manageGroups.edit.fail=Group edit failed.
-dataverse.manageGroups.save.fail=Group Save failed.
+dataverse.manageGroups.delete=Le groupe a été supprimé.
+dataverse.manageGroups.nodelete=Le groupe explicite ne peut pas être supprimé.
+dataverse.manageGroups.create.fail=La création de groupe a échoué.
+dataverse.manageGroups.edit.fail=La modification de groupe a échoué.
+dataverse.manageGroups.save.fail=La sauvegarde de groupe a échoué.
 
 #ManageTemplatesPage.java
-
 template.makeDefault=Le modèle a été sélectionné comme modèle par défaut pour ce dataverse
 template.unselectDefault=Le modèle a été supprimé en tant que modèle par défaut pour ce dataverse
 template.clone=Le modèle a été copié
@@ -2011,13 +2010,11 @@ template.makeDefault.error=Le modèle de l'ensemble de données ne peut pas être d
 page.copy=Copie de
 
 #RolePermissionFragment.java
-permission.roleAssignedToOn=Role {0} assigned to {1} on {2}
-permission.cannotAssignRole=Can't assign role: {0}
-permission.roleRevoked=Role assignment revoked successfully
-permission.cannotRevokeRole1=Cannot revoke role assignment - you're missing permission {0}
-permission.cannotRevokeRole2=Cannot revoke role assignment: {0}
-permission.roleSave=Role &#34;{0}&#34; saved
-permission.cannotSaveRole=Cannot save role {0}
-
-
+permission.roleAssignedToOn=Rôle {0} assigné à {1} pour {2}
+permission.cannotAssignRole=Le rôle n'a pu être assigné\u00A0: {0}
+permission.roleRevoked=Attribution de rôle révoquée avec succès
+permission.cannotRevokeRole1=Impossible de révoquer l'attribution de rôle - il vous manque la permission {0}
+permission.cannotRevokeRole2=Impossible de révoquer l'attribution de rôle\u00A0: {0}
+permission.roleSave=Le rôle «\u00A0{0}\u00A0» a été sauvegardé
+permission.cannotSaveRole=Impossible de sauvegarder le rôle {0}
  


### PR DESCRIPTION
@JayanthyChengan

Here is the latest French translation.

A few comments and questions:

1) I made sure all variables in the English Bundle file were also in the French one and I made sure variables and line numbers were even and were the same between the two files (it's easier to spot errors that way I think)

2) I did add the dataset.compute.* variables that were not in your original https://github.com/scholarsportal/dataverse/blob/BundleProperties/src/main/java/Bundle_fr.properties file. Is that OK?

3) I was not sure how to translate those 3 variables (Are those pieces of code or text variables?):
dataverse.notreleased=DataverseNotReleased
dataset.registered=DatasetRegistered
dataset.notlinked=DatasetNotLinked

For now I translated them as text equivalent (Dataverse Not Released => Dataverse non publié). If it turns out to be code, maybe you will have to adjust the Bundle_fr file (Or remove those variables from the Bundle properties file?).


4) Regarding my last email (i.e. insertion of Unicode characters), I saw that the English Bundle file contains both syntax (ISO-8859-1 and Unicode UTF-16):

ex.:

- file.viewDiffDialog.msg.draftFound=`&#160;`This

 is the "DRAFT" version. (https://github.com/scholarsportal/dataverse/blob/BundleProperties/src/main/java/Bundle.properties#L1570)
and

- dataset.inreview.infoMessage=`\u2013`

 This dataset is currently under review prior to publication. (https://github.com/scholarsportal/dataverse/blob/BundleProperties/src/main/java/Bundle.properties#L1163)

So on my side I decided to standardize all characters with the UTF-16 code hex-value. Is that OK?

Please note that it is important to keep those non breaking spaces before ":" and in between «» (I don't know why they were taken off from my former version; I had to review and reinsert them)

Ex.:

- passwdReset.emailSubmitted=Courriel

 soumis`\u00A0`:
and

- dataverse.manageGroups.noGroups.getStarted=Pour

 débuter, cliquez sur le bouton «`\u00A0`Créer un groupe`\u00A0`» ci-dessus.