### PR TITLE
Fixes for French translation (apostrophes escaping+hyphens to emdashes)

### DIFF
--- a/src/main/java/Bundle_fr.properties
+++ b/src/main/java/Bundle_fr.properties
@@ -171,9 +171,9 @@ notification.requestFileAccess=Demande d'accès pour l''ensemble de données\u00A0
 notification.grantFileAccess=Accès accordé pour les fichiers de l''ensemble de données\u00A0: {0}.
 notification.rejectFileAccess=Demande d''accès refusée pour les fichiers de l''ensemble de données\u00A0: {0}.
 notification.createDataverse={0} a été créé dans {1}. Pour savoir ce que vous pouvez faire avec votre dataverse, consultez le {2}.
-notification.dataverse.management.title=Administration de Dataverse — Guide d'utilisation de Dataverse
+notification.dataverse.management.title=Administration de Dataverse \u2014 Guide d'utilisation de Dataverse
 notification.createDataset={0} a été créé dans {1}. Pour savoir ce que vous pouvez faire avec votre ensemble de données, consultez le {2}.
-notification.dataset.management.title=Administration des ensembles de données — Guide d'utilisation pour les ensembles de données
+notification.dataset.management.title=Administration des ensembles de données \u2014 Guide d'utilisation pour les ensembles de données
 notification.wasSubmittedForReview={0} a été soumis pour vérification avant publication dans {1}. N''oubliez pas de le publier ou de le renvoyer au collaborateur\!
 notification.wasReturnedByReviewer={0} a été retourné par l''intendant des données de {1}.
 notification.wasPublished={0} a été publié dans {1}.
@@ -195,7 +195,7 @@ notification.import.checksum=<a href="/dataset.xhtml?persistentId={0}" title="{1
 removeNotification=Supprimer l'avis
 groupAndRoles.manageTips=Vous pouvez gérer tous les groupes dont vous êtes membre et les rôles qui vous ont été confiés et y avoir accès.
 user.signup.tip=Pourquoi se créer un compte Dataverse? De façon à pouvoir créer votre propre dataverse, le personnaliser, y ajouter des ensembles de données, ou encore pour demander l'accès à des fichiers à accès réservé. 
-user.signup.otherLogInOptions.tip=<a href="/loginpage.xhtml" title="Dataverse — Se connecter">Voir les autres options de connexion.</a>
+user.signup.otherLogInOptions.tip=<a href="/loginpage.xhtml" title="Dataverse \u2014 Se connecter">Voir les autres options de connexion.</a>
 user.username.illegal.tip=Votre nom d'utilisateur doit compter entre 2 et 60\u00A0caractères et vous pouvez utiliser les lettres a à z, les chiffres 0 à 9 et le caractère souligné «\u00A0_\u00A0».
 user.username=Nom d'utilisateur
 user.username.taken=Ce nom d'utilisateur est déjà pris.
@@ -255,7 +255,7 @@ login.System=Système d'authentification
 login.forgot.text=Mot de passe oublié?
 login.builtin=Compte Dataverse
 login.institution=Compte institutionnel
-login.institution.blurb=Connectez-vous ou inscrivez-vous avec votre compte institutionnel — <a href="{0}/{1}/user/account.html" target="_blank">En apprendre davantage</a>.
+login.institution.blurb=Connectez-vous ou inscrivez-vous avec votre compte institutionnel \u2014 <a href="{0}/{1}/user/account.html" target="_blank">En apprendre davantage</a>.
 login.institution.support.beforeLink=Vous quittez votre établissement? Prière de contacter
 login.institution.support.afterLink=pour obtenir de l'aide.
 login.builtin.credential.usernameOrEmail=Nom d'utilisateur/courriel
@@ -275,7 +275,7 @@ auth.providers.title.shib=Votre établissement
 auth.providers.title.orcid=ORCID
 auth.providers.title.google=Google
 auth.providers.title.github=GitHub
-auth.providers.blurb=Connectez-vous ou inscrivez-vous avec votre compte {0} — <a href="{1}/{2}/user/account.html" target="_blank">En apprendre davantage</a>. Vous éprouvez des problèmes? Veuillez contacter {3} pour obtenir de l''aide.
+auth.providers.blurb=Connectez-vous ou inscrivez-vous avec votre compte {0} \u2014 <a href="{1}/{2}/user/account.html" target="_blank">En apprendre davantage</a>. Vous éprouvez des problèmes? Veuillez contacter {3} pour obtenir de l''aide.
 auth.providers.persistentUserIdName.orcid=ORCID iD
 auth.providers.persistentUserIdName.github=Identifiant GitHub
 auth.providers.persistentUserIdTooltip.orcid=ORCID fournit un identifiant numérique pérenne qui vous distingue des autres chercheurs.
@@ -315,7 +315,7 @@ shib.dataverseUsername=Nom d'utilisateur Dataverse
 shib.currentDataversePassword=Mot de passe Dataverse actuel
 shib.accountInformation=Renseignements sur le compte
 shib.offerToCreateNewAccount=Cette information est fournie par votre établissement et sera employée pour créer votre compte Dataverse.
-shib.passwordRejected=<strong>Erreur de validation</strong> — Votre compte peut uniquement être converti si vous indiquez le bon mot de passe pour votre compte existant.
+shib.passwordRejected=<strong>Erreur de validation</strong> \u2014 Votre compte peut uniquement être converti si vous indiquez le bon mot de passe pour votre compte existant.
 
 # oauth2/firstLogin.xhtml
 oauth2.btn.convertAccount=Convertir le compte existant
@@ -326,7 +326,7 @@ oauth2.welcomeExistingUserMessageDefaultInstitution=votre établissement
 oauth2.dataverseUsername=Nom d'utilisateur Dataverse
 oauth2.currentDataversePassword=Mot de passe Dataverse actuel
 oauth2.chooseUsername=Nom d'utilisateur\u00A0: 
-oauth2.passwordRejected=<strong>Erreur de validation</strong> — Nom d'utilisateur ou mot de passe incorrect.
+oauth2.passwordRejected=<strong>Erreur de validation</strong> \u2014 Nom d'utilisateur ou mot de passe incorrect.
 # oauth2.newAccount.title=Création de compte
 oauth2.newAccount.welcomeWithName=Bienvenue dans Dataverse, {0}
 oauth2.newAccount.welcomeNoName=Bienvenue dans Dataverse
@@ -350,13 +350,13 @@ oauth2.newAccount.emailInvalid=Adresse courriel non valide.
 oauth2.convertAccount.explanation=Entrez votre nom d''utilisateur {0} ou votre courriel ainsi que votre mot de passe pour convertir votre compte à l''option de connexion {1}. <a href="{2}/{3}/user/account.html" target="_blank">En apprendre davantage</a> à propos de la conversion de votre compte.
 oauth2.convertAccount.username=Nom d'utilisateur existant
 oauth2.convertAccount.password=Mot de passe
-oauth2.convertAccount.authenticationFailed=Authentification échouée — Nom d'utilisateur ou mot de passe incorrect.
+oauth2.convertAccount.authenticationFailed=Authentification échouée \u2014 Nom d'utilisateur ou mot de passe incorrect.
 oauth2.convertAccount.buttonTitle=Convertir un compte
 oauth2.convertAccount.success=Votre compte Dataverse est maintenant associé à votre compte {0}.
 
 # oauth2/callback.xhtml
 oauth2.callback.page.title=Rappel OAuth
-oauth2.callback.message=<strong>Erreur d''authentification</strong> — Dataverse n''a pas pu authentifier votre connexion ORCID. Assurez-vous d''autoriser votre compte ORCID à se connecter à Dataverse. Pour plus de détails sur les informations demandées, voir la section <a href="{0}/{1}/user/account.html#orcid-log-in" title="Authentification ORCID — Guide d''utilisation de Dataverse" target="_blank">authentification ORCID</a> du guide d''utilisation.
+oauth2.callback.message=<strong>Erreur d''authentification</strong> \u2014 Dataverse n''a pas pu authentifier votre connexion ORCID. Assurez-vous d''autoriser votre compte ORCID à se connecter à Dataverse. Pour plus de détails sur les informations demandées, voir la section <a href="{0}/{1}/user/account.html#orcid-log-in" title="Authentification ORCID \u2014 Guide d''utilisation de Dataverse" target="_blank">authentification ORCID</a> du guide d''utilisation.
 
 # tab on dataverseuser.xhtml
 apitoken.title=Jeton API
@@ -390,7 +390,7 @@ harvestclients.noClients.why.reason2=Les notices de métadonnées moissonnées sont
 harvestclients.noClients.how.header=Comment effectuer le moissonnage
 harvestclients.noClients.how.tip1=Afin de pouvoir moissonner des métadonnées, un <i>client de moissonnage</i> doit être défini et paramétré pour chacun des dépôts distants. Veuillez noter que pour définir un client, vous devrez sélectionner un dataverse local déjà existant, lequel hébergera les ensembles de données moissonnés.
 harvestclients.noClients.how.tip2=Les notices récoltées peuvent être synchronisées avec le dépôt d'origine à l'aide de mises à jour incrémentielles programmées, par exemple, quotidiennes ou hebdomadaires. Alternativement, les moissonnages peuvent être exécutés à la demande, à partir de cette page ou via l'API REST.
-harvestclients.noClients.getStarted=Pour commencer, cliquez sur le bouton «\u00A0Ajouter un client\u00A0» ci-dessus. Pour en apprendre davantage sur le moissonnage, consultez la section <a href="{0}/{1}/user/index.html#index" title="Moissonnage — Guide d''utilisation de Dataverse" target="_blank">moissonnage</a> du guide d''utilisation.
+harvestclients.noClients.getStarted=Pour commencer, cliquez sur le bouton «\u00A0Ajouter un client\u00A0» ci-dessus. Pour en apprendre davantage sur le moissonnage, consultez la section <a href="{0}/{1}/user/index.html#index" title="Moissonnage \u2014 Guide d''utilisation de Dataverse" target="_blank">moissonnage</a> du guide d''utilisation.
 harvestclients.btn.add=Ajouter un client
 harvestclients.tab.header.name=Alias
 harvestclients.tab.header.url=Adresse URL
@@ -405,7 +405,7 @@ harvestclients.tab.header.action.btn.delete.dialog.warning=Voulez-vous vraiment 
 harvestclients.tab.header.action.btn.delete.dialog.tip=Veuillez noter que cette opération peut prendre un certain temps à effectuer en fonction du nombre d'ensembles de données récoltés.
 harvestclients.tab.header.action.delete.infomessage=La suppression du client de moissonnage est lancée. Notez que cela peut prendre un certain temps en fonction de la quantité de contenu récolté.
 harvestclients.actions.runharvest.success=Lancement réussi d''un moissonnage asynchrone pour le client «\u00A0{0}\u00A0». Veuillez recharger la page pour vérifier les résultats de la récolte.
-harvestclients.newClientDialog.step1=Étape 1 de 4 — Renseignements au sujet du client
+harvestclients.newClientDialog.step1=Étape 1 de 4 \u2014 Renseignements au sujet du client
 harvestclients.newClientDialog.title.new=Définir un client de moissonnage
 harvestclients.newClientDialog.help=Configurer un client pour moissonner le contenu d'un serveur distant
 harvestclients.newClientDialog.nickname=Alias
@@ -431,7 +431,7 @@ harvestclients.newClientDialog.dataverse.menu.enterName=Saisir l'alias du datave
 harvestclients.newClientDialog.dataverse.menu.header=Nom du dataverse (affiliation), alias
 harvestclients.newClientDialog.dataverse.menu.invalidMsg=Aucun résultat
 harvestclients.newClientDialog.dataverse.required=Vous devez sélectionner un dataverse existant pour ce client de moissonnage.
-harvestclients.newClientDialog.step2=Étape 2 de 4 — Format
+harvestclients.newClientDialog.step2=Étape 2 de 4 \u2014 Format
 harvestclients.newClientDialog.oaiSets=Ensemble OAI
 harvestclients.newClientDialog.oaiSets.tip=Ensembles moissonnables offerts par ce serveur OAI.
 harvestclients.newClientDialog.oaiSets.noset=Aucun
@@ -440,7 +440,7 @@ harvestclients.newClientDialog.oaiSets.helptext.noset=Ce serveur OAI ne prend pa
 harvestclients.newClientDialog.oaiMetadataFormat=Format des métadonnées
 harvestclients.newClientDialog.oaiMetadataFormat.tip=Formats de métadonnées offerts par le serveur distant.
 harvestclients.newClientDialog.oaiMetadataFormat.required=Veuillez sélectionner le format de métadonnées à utiliser pour le moissonnage de ce dépôt.
-harvestclients.newClientDialog.step3=Étape 3 de 4 — Planifier
+harvestclients.newClientDialog.step3=Étape 3 de 4 \u2014 Planifier
 harvestclients.newClientDialog.schedule=Périodicité
 harvestclients.newClientDialog.schedule.tip=Programmer le moissonnage pour qu'il s'exécute automatiquement de façon quotidienne ou hebdomadaire.
 harvestclients.newClientDialog.schedule.time.none.helptext=Ne pas spécifier de périodicité de moissonnage de sorte que l'exécution se fera sur demande seulement.
@@ -454,7 +454,7 @@ harvestclients.newClientDialog.schedule.time.pm=p.m.
 harvestclients.newClientDialog.schedule.time.helptext=L'horaire programmé se réfère à votre heure locale.
 harvestclients.newClientDialog.btn.create=Créer un client
 harvestclients.newClientDialog.success=Le client de moissonnage «\u00A0{0}\u00A0» a bien été créé.
-harvestclients.newClientDialog.step4=Étape 4 de 4 — Affichage
+harvestclients.newClientDialog.step4=Étape 4 de 4 \u2014 Affichage
 harvestclients.newClientDialog.harvestingStyle=Type de dépôt
 harvestclients.newClientDialog.harvestingStyle.tip=Type du dépôt distant.
 harvestclients.newClientDialog.harvestingStyle.helptext=Sélectionnez le type de dépôt qui décrit le mieux ce serveur distant afin d'appliquer correctement les règles de formatage et de style aux métadonnées récoltées lors de leur affichage dans les résultats de recherche. Notez qu'une sélection incorrecte du type de dépôt distant peut entraîner l'affichage incomplet des entrées dans les résultats de recherche causant ainsi une impossibilité de rediriger l'utilisateur vers le dépôt source des données.
@@ -470,7 +470,7 @@ harvestclients.newClientDialog.title.edit=Modifier le groupe {0}
 
 #harvestset.xhtml
 harvestserver.title=Administration du serveur de moissonnage
-harvestserver.toptip=— Définir les collections d'ensembles de données locaux qui seront disponibles pour le moissonnage par les clients distants.
+harvestserver.toptip=\u2014 Définir les collections d'ensembles de données locaux qui seront disponibles pour le moissonnage par les clients distants.
 harvestserver.service.label=Serveur OAI
 harvestserver.service.enabled=Activé
 harvestserver.service.disabled=Désactivé
@@ -482,8 +482,8 @@ harvestserver.noSets.why.reason1=Le moissonnage consiste à échanger des métadonn
 harvestserver.noSets.why.reason2=Seuls les ensembles de données publiés et non restreints de votre Dataverse peuvent être moissonnés. Les clients distants maintiennent normalement leurs enregistrements synchronisés grâce à des mises à jour incrémentielles programmées, quotidiennes ou hebdomadaires, réduisant ainsi la charge sur votre serveur. Notez que seules les métadonnées sont moissonnées. Les moissonneurs distants ne tentent généralement pas de télécharger eux-mêmes les fichiers de données.
 harvestserver.noSets.how.header=Comment activer un serveur de moissonnage?
 harvestserver.noSets.how.tip1=Le serveur de moissonnage peut être activé ou désactivé à partir de cette page. 
-harvestserver.noSets.how.tip2=Une fois le service activé, vous pouvez définir des collections d'ensembles de données locaux qui seront disponibles pour les moissonneurs distants sous <i>Ensembles OAI</i>. Les ensembles sont définis par des requêtes de recherche (par exemple, authorName:king; ou parentId:1234 — pour sélectionner tous les ensembles de données appartenant au dataverse spécifié; ou dsPersistentId:"doi:1234/" pour sélectionner tous les ensembles de données avec l'identifiant perenne spécifié). Consultez la section sur l'API de recherche du guide d'utilisation de Dataverse pour plus d'informations sur les requêtes de recherche.  
-harvestserver.noSets.getStarted=Pour commencer, activez le serveur OAI et cliquez sur le bouton «\u00A0Ajouter un ensemble (set)\u00A0». Pour en apprendre plus sur le moissonnage, consultez la section  <a href="{0}/{1}/user/index.html#index" title="Moissonnage — Guide d''utilisation de Dataverse" target="_blank">moissonnage</a> du guide d''utilisation.
+harvestserver.noSets.how.tip2=Une fois le service activé, vous pouvez définir des collections d'ensembles de données locaux qui seront disponibles pour les moissonneurs distants sous <i>Ensembles OAI</i>. Les ensembles sont définis par des requêtes de recherche (par exemple, authorName:king; ou parentId:1234 \u2014 pour sélectionner tous les ensembles de données appartenant au dataverse spécifié; ou dsPersistentId:"doi:1234/" pour sélectionner tous les ensembles de données avec l'identifiant perenne spécifié). Consultez la section sur l'API de recherche du guide d'utilisation de Dataverse pour plus d'informations sur les requêtes de recherche.  
+harvestserver.noSets.getStarted=Pour commencer, activez le serveur OAI et cliquez sur le bouton «\u00A0Ajouter un ensemble (set)\u00A0». Pour en apprendre plus sur le moissonnage, consultez la section  <a href="{0}/{1}/user/index.html#index" title="Moissonnage \u2014 Guide d''utilisation de Dataverse" target="_blank">moissonnage</a> du guide d''utilisation.
 harvestserver.btn.add=Ajouter un ensemble (set)
 harvestserver.tab.header.spec=setSpec OAI (identifiant OAI de l'ensemble)
 harvestserver.tab.header.description=Description
@@ -527,7 +527,7 @@ harvestserver.viewEditDialog.btn.save=Sauvegarder les modifications
 
 #dashboard-users.xhtml
 dashboard.card.users=Utilisateurs
-dashboard.card.users.header=Tableau de bord — Liste des utilisateurs
+dashboard.card.users.header=Tableau de bord \u2014 Liste des utilisateurs
 dashboard.card.users.super=Super-utilisateurs
 dashboard.card.users.manage=Gérer les utilisateurs
 dashboard.card.users.message=Lister et gérer les utilisateurs.
@@ -608,14 +608,14 @@ pageTitle.passwdReset.pre=Réinitialisation du mot de passe du compte
 passwdReset.token=Jeton\u00A0:
 passwdReset.userLookedUp=Utilisateur recherché\u00A0:
 passwdReset.emailSubmitted=Courriel soumis\u00A0:
-passwdReset.details={0} Réinitialisation du mot de passe{1} — Pour débuter le processus de réinitialisation du mot de passe, veuillez indiquer votre adresse courriel. 
+passwdReset.details={0} Réinitialisation du mot de passe{1} \u2014 Pour débuter le processus de réinitialisation du mot de passe, veuillez indiquer votre adresse courriel. 
 passwdReset.submitRequest=Soumettre la demande de mot de passe
 passwdReset.successSubmit.tip=Si cette adresse courriel est associée à un compte, un courriel sera envoyé avec des instructions supplémentaires à {0}.
 passwdReset.debug=DÉBOGUER
 passwdReset.resetUrl=L'adresse URL réinitialisée est
 passwdReset.noEmail.tip=Aucun courriel n''a été envoyé étant donné qu''aucun utilisateur n''a été trouvé au moyen de l''adresse fournie {0}. Nous ne le mentionnons pas, car nous voulons éviter que des utilisateurs malveillants se servent du formulaire pour déterminer si un compte est associé à une adresse courriel. 
 passwdReset.illegalLink.tip=Le lien pour réinitialiser votre mot de passe n''est pas valide. Si vous devez réinitialiser votre mot de passe, {0}cliquez ici{1} pour demander à ce que votre mot de passe soit réinitialisé.
-passwdReset.newPasswd.details={0} Réinitialiser le mot de passe{1} — Nos exigences de composition de mot de passe ont changé. Veuillez choisir un mot de passe sécuritaire respectant les critères énumérés ci-après. 
+passwdReset.newPasswd.details={0} Réinitialiser le mot de passe{1} \u2014 Nos exigences de composition de mot de passe ont changé. Veuillez choisir un mot de passe sécuritaire respectant les critères énumérés ci-après. 
 passwdReset.newPasswd=Nouveau mot de passe
 passwdReset.rePasswd=Confirmer le mot de passe
 passwdReset.resetBtn=Réinitialiser le mot de passe  
@@ -712,7 +712,7 @@ dataverse.delete=Supprimer le dataverse
 dataverse.delete.success=Votre dataverse a été supprimé.
 dataverse.delete.failure=Ce dataverse n'a pas pu être supprimé. 
 # Bundle file editors, please note that "dataverse.create.success" is used in a unit test because it's so fancy with two parameters
-dataverse.create.success=Vous avez bien réussi à créer votre dataverse! Pour en apprendre davantage sur ce que vous pouvez faire avec votre dataverse, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Administration de Dataverse — Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
+dataverse.create.success=Vous avez bien réussi à créer votre dataverse! Pour en apprendre davantage sur ce que vous pouvez faire avec votre dataverse, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Administration de Dataverse \u2014 Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
 dataverse.create.failure=Ce dataverse n'a pas pu être créé. 
 dataverse.create.authenticatedUsersOnly=Seuls les utilisateurs authentifiés peuvent créer des dataverses.
 dataverse.update.success=Vous avez bien mis à jour votre dataverse!
@@ -759,15 +759,15 @@ dataverse.results.types.dataverses=Dataverses
 dataverse.results.types.datasets=Ensembles de données
 dataverse.results.types.files=Fichiers
 # Bundle file editors, please note that "dataverse.results.empty.zero" is used in a unit test
-dataverse.results.empty.zero=Aucun dataverse, ensemble de données ou fichier ne correspond à votre recherche. Veuillez effectuer une nouvelle recherche en utilisant d''autres termes ou des termes plus généraux. Vous pouvez également consulter le <a href="{0}/{1}/user/find-use-data.html" title="Trouver et utiliser des données — Guide d''utilisation de Dataverse" target="_blank">guide de recherche</a> pour des astuces.
+dataverse.results.empty.zero=Aucun dataverse, ensemble de données ou fichier ne correspond à votre recherche. Veuillez effectuer une nouvelle recherche en utilisant d''autres termes ou des termes plus généraux. Vous pouvez également consulter le <a href="{0}/{1}/user/find-use-data.html" title="Trouver et utiliser des données \u2014 Guide d''utilisation de Dataverse" target="_blank">guide de recherche</a> pour des astuces.
 # Bundle file editors, please note that "dataverse.results.empty.hidden" is used in a unit test
-dataverse.results.empty.hidden=Il n''y a pas de résultats répondants à vos critères de recherche. Vous pouvez consulter le <a href="{0}/{1}/user/find-use-data.html" title="Trouver et utiliser des données — Guide d''utilisation de Dataverse" target="_blank">guide de recherche</a> pour des conseils.
+dataverse.results.empty.hidden=Il n''y a pas de résultats répondants à vos critères de recherche. Vous pouvez consulter le <a href="{0}/{1}/user/find-use-data.html" title="Trouver et utiliser des données \u2014 Guide d''utilisation de Dataverse" target="_blank">guide de recherche</a> pour des conseils.
 dataverse.results.empty.browse.guest.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Veuillez <a href="/loginpage.xhtml{0}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour voir si vous pouvez y ajouter du contenu. 
 dataverse.results.empty.browse.guest.hidden=Ce dataverse ne contient aucun dataverse. Veuillez <a href="/loginpage.xhtml{0}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour voir si vous pouvez y ajouter du contenu. 
 dataverse.results.empty.browse.loggedin.noperms.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Vous pouvez utiliser le bouton «\u00A0Envoyer un courriel au contact du dataverse\u00A0» ci-dessus pour toute question sur ce dataverse ou pour effectuer une demande d'accès à ce dataverse.
 dataverse.results.empty.browse.loggedin.noperms.hidden=Il n'y a aucun dataverse dans ce dataverse.
 dataverse.results.empty.browse.loggedin.perms.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Vous pouvez en ajouter à l'aide du bouton «\u00A0Ajouter des données\u00A0» qui se trouve sur cette page.
-account.results.empty.browse.loggedin.perms.zero=Il n''y a aucun dataverse, ensemble de données ou fichier associé à votre compte. Vous pouvez ajouter un dataverse ou un ensemble de données en cliquant sur le bouton «\u00A0Ajouter des données\u00A0» ci-dessus. Pour en apprendre davantage sur l''ajout de données, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Administration de Dataverse — Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
+account.results.empty.browse.loggedin.perms.zero=Il n''y a aucun dataverse, ensemble de données ou fichier associé à votre compte. Vous pouvez ajouter un dataverse ou un ensemble de données en cliquant sur le bouton «\u00A0Ajouter des données\u00A0» ci-dessus. Pour en apprendre davantage sur l''ajout de données, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Administration de Dataverse \u2014 Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
 dataverse.results.empty.browse.loggedin.perms.hidden=Il n'y a aucun dataverse dans ce dataverse. Vous pouvez en ajouter à l'aide du bouton «\u00A0Ajouter des données\u00A0» qui se trouve sur cette page.
 dataverse.results.empty.link.technicalDetails=Plus de détails techniques
 dataverse.search.facet.error=Une erreur s''est produite avec vos paramètres de recherche. Veuillez <a href="/dataverse/{0}">supprimer votre recherche</a> et essayer de nouveau.
@@ -836,9 +836,9 @@ dataverse.widgets.notPublished.why.reason2=Permet aux autres de parcourir votre 
 dataverse.widgets.notPublished.how.header=Comment utiliser les widgets
 dataverse.widgets.notPublished.how.tip1=Pour pouvoir utiliser des widgets, votre dataverse et vos ensembles de données doivent être publiés.
 dataverse.widgets.notPublished.how.tip2=Suite à la publication, le code sera disponible sur cette page pour que vous puissiez le copier et l'ajouter à votre site web personnel ou de projet.
-dataverse.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l''ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title = "Ajouter des widgets à un site web OpenScholar — Guide d''utilisation de Dataverse" target ="_blank">ici</a>.
-dataverse.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets — Guide d''utilisation de Dataverse" target="_blank">thème et widgets</a> du guide d''utilisation.
-dataverse.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets — Guide d''utilisation de Dataverse" target="_blank">Thème et widgets</a> du guide d''utilisation.
+dataverse.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l''ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title = "Ajouter des widgets à un site web OpenScholar \u2014 Guide d''utilisation de Dataverse" target ="_blank">ici</a>.
+dataverse.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets \u2014 Guide d''utilisation de Dataverse" target="_blank">thème et widgets</a> du guide d''utilisation.
+dataverse.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets \u2014 Guide d''utilisation de Dataverse" target="_blank">Thème et widgets</a> du guide d''utilisation.
 dataverse.widgets.searchBox.txt=Boîte de recherche Dataverse
 dataverse.widgets.searchBox.tip=Permet aux visiteurs de votre site Web d'effectuer une recherche dans Dataverse.
 dataverse.widgets.dataverseListing.txt=Liste des dataverses
@@ -927,9 +927,9 @@ dataverse.permissions.Q1.answer2=Toute personne possédant un compte Dataverse pe
 dataverse.permissions.Q1.answer3=Toute personne possédant un compte Dataverse peut ajouter des ensembles de données.
 dataverse.permissions.Q1.answer4=Toute personne possédant un compte Dataverse peut ajouter des sous-dataverses et des ensembles de données.
 dataverse.permissions.Q2=Lorsqu'un utilisateur ajoute un nouvel ensemble de données à ce dataverse, quel rôle doit-il lui être attribué automatiquement sur cet ensemble de données?
-dataverse.permissions.Q2.answer.editor.description=— Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, soumettre les ensembles de données aux fins d'examen.
-dataverse.permissions.Q2.answer.manager.description=— Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, les restrictions relatives aux fichiers (accès aux fichiers + utilisation)
-dataverse.permissions.Q2.answer.curator.description=— Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, les restrictions relatives aux fichiers (accès aux fichiers + utilisation), modifier les permissions/assigner les rôles + publier
+dataverse.permissions.Q2.answer.editor.description=\u2014 Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, soumettre les ensembles de données aux fins d'examen.
+dataverse.permissions.Q2.answer.manager.description=\u2014 Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, les restrictions relatives aux fichiers (accès aux fichiers + utilisation)
+dataverse.permissions.Q2.answer.curator.description=\u2014 Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, les restrictions relatives aux fichiers (accès aux fichiers + utilisation), modifier les permissions/assigner les rôles + publier
 permission.anyoneWithAccount=Toute personne possédant un compte Dataverse
 
 # roles-assign.xhtml
@@ -982,7 +982,7 @@ dataset.manageTemplates.noTemplates.why.reason2=Les modèles peuvent être utilisé
 dataset.manageTemplates.noTemplates.how.header=Comment utiliser les modèles
 dataset.manageTemplates.noTemplates.how.tip1=Les modèles sont créés au niveau du dataverse, peuvent être supprimés (si on ne veut pas qu'ils paraissent dans les futurs ensembles de données), sont activés par défaut (non requis) et peuvent être copiés de façon à ce que vous n'ayez pas à recommencer du début lorsque vous créez un nouveau modèle contenant des métadonnées similaires à un autre modèle. Lorsqu'un modèle est supprimé, il n'y a aucune incidence sur les ensembles de données qui ont déjà utilisé le modèle.
 dataset.manageTemplates.noTemplates.how.tip2=Veuillez noter que la possibilité de choisir les champs de métadonnées qui seront cachés, obligatoires ou facultatifs est disponible sur la page <a href="/dataverse/{0}?editMode=INFO" title="Renseignements généraux sur Dataverse">Renseignements généraux</a> de ce dataverse.
-dataset.manageTemplates.noTemplates.getStarted=Pour commencer, cliquez sur le bouton «\u00A0Créer un modèle d''ensemble de données\u00A0» ci-dessus. Pour en apprendre davantage au sujet des modèles, consultez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-templates" title="Modèles d''ensemble de données — Guide d''utilisation de Dataverse" target="_blank">modèles d''ensemble de données</a>du guide d''utilisation.
+dataset.manageTemplates.noTemplates.getStarted=Pour commencer, cliquez sur le bouton «\u00A0Créer un modèle d''ensemble de données\u00A0» ci-dessus. Pour en apprendre davantage au sujet des modèles, consultez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-templates" title="Modèles d''ensemble de données \u2014 Guide d''utilisation de Dataverse" target="_blank">modèles d''ensemble de données</a>du guide d''utilisation.
 dataset.manageTemplates.tab.header.templte=Nom du modèle
 dataset.manageTemplates.tab.header.date=Date de création
 dataset.manageTemplates.tab.header.usage=Usage
@@ -1060,7 +1060,7 @@ dataset.manageGuestbooks.noGuestbooks.why.reason2=Vous pouvez télécharger les do
 dataset.manageGuestbooks.noGuestbooks.how.header=Comment utiliser les registres de visiteurs
 dataset.manageGuestbooks.noGuestbooks.how.tip1=Un registre des visiteurs peut être utilisé pour plusieurs ensembles de données, mais un seul registre des visiteurs peut être utilisé pour un ensemble de données.
 dataset.manageGuestbooks.noGuestbooks.how.tip2=Les questions personnalisées peuvent comprendre des réponses en texte libre ou des questions à choice de réponses.
-dataset.manageGuestbooks.noGuestbooks.getStarted=Pour commencer, cliquez ci-dessus sur le bouton «\u00A0Créer un registre des visiteurs pour l''ensemble de données\u00A0». Pour en apprendre davantage sur les registres de visiteurs, visitez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-guestbooks" title="Registre des visiteurs de l''ensemble de données — Guide d''utilisation de Dataverse" target="_blank">registre des visiteurs</a> du guide d''utilisation.
+dataset.manageGuestbooks.noGuestbooks.getStarted=Pour commencer, cliquez ci-dessus sur le bouton «\u00A0Créer un registre des visiteurs pour l''ensemble de données\u00A0». Pour en apprendre davantage sur les registres de visiteurs, visitez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-guestbooks" title="Registre des visiteurs de l''ensemble de données \u2014 Guide d''utilisation de Dataverse" target="_blank">registre des visiteurs</a> du guide d''utilisation.
 dataset.manageGuestbooks.tab.header.name=Nom du registre des visiteurs
 dataset.manageGuestbooks.tab.header.date=Date de création
 dataset.manageGuestbooks.tab.header.usage=Usage
@@ -1161,7 +1161,7 @@ dataset.disabledSubmittedBtn=Soumis à la révision
 dataset.submitMessage=Vous ne serez pas en mesure d'apporter des modifications à cet ensemble de données pendant sa révision.
 dataset.submit.success=Votre ensemble de données a été soumis pour révision.
 dataset.inreview.infoMessage=\u2013 Cet ensemble de données est actuellement en cours de révision avant publication.
-dataset.submit.failure=Échec de la soumission de l''ensemble de données — {0}
+dataset.submit.failure=Échec de la soumission de l''ensemble de données \u2014 {0}
 dataset.submit.failure.null=Impossible de soumettre à la révision. L'ensemble de données est nul.
 dataset.submit.failure.isReleased=La dernière version de l'ensemble de données est déjà publiée. Seules les versions provisoires peuvent être soumises pour révision.
 dataset.submit.failure.inReview=Vous ne pouvez pas soumettre cet ensemble de données à la révision, car il est déjà en cours de vérification.
@@ -1170,7 +1170,7 @@ dataset.rejectWatermark=Veuillez entrer une raison pour laquelle cet ensemble de
 dataset.reject.enterReason=La raison du retour à l'auteur est requise
 dataset.reject.enterReason.header=Entrée obligatoire
 dataset.reject.success=Cet ensemble de données à été renvoyé au collaborateur.
-dataset.reject.failure=Échec de la soumission du renvoi de l''ensemble de données — {0}
+dataset.reject.failure=Échec de la soumission du renvoi de l''ensemble de données \u2014 {0}
 dataset.reject.datasetNull=Impossible de renvoyer l'ensemble de données à l'auteur (s) car il est null.
 dataset.reject.datasetNotInReview=Cet ensemble de données ne peut pas être renvoyé à (aux) l'auteur (s), car la dernière version n'est pas en révision. L' (les) auteur(s) doit (doivent) d'abord cliquer sur «\u00A0Soumettre pour révision\u00A0».
 dataset.publish.tip=Êtes-vous sûr(e) de vouloir publier cet ensemble de données? Une fois publié, il doit demeurer publié.
@@ -1221,7 +1221,7 @@ dataset.versionUI.deaccessioned=Retirée
 dataset.cite.title.released=La VERSION PROVISOIRE sera remplacée dans la référence bibliographique par la V1 une fois l'ensemble de données publié.
 dataset.cite.title.draft=La VERSION PROVISOIRE sera remplacée dans la référence bibliographique par la version sélectionnée une fois l'ensemble de données publié.
 dataset.cite.title.deassessioned=La mention VERSION RETIRÉE a été ajoutée à la référence bibliographique pour cette version étant donné qu'elle n'est plus disponible.
-dataset.cite.standards.tip=Pour en apprendre davantage sur le sujet, consultez le document <a href="https://dataverse.org/best-practices/data-citation" title="Data Citation — Dataverse Best Practices" target="_blank">Data Citation Standards [en]</a>.
+dataset.cite.standards.tip=Pour en apprendre davantage sur le sujet, consultez le document <a href="https://dataverse.org/best-practices/data-citation" title="Data Citation \u2014 Dataverse Best Practices" target="_blank">Data Citation Standards [en]</a>.
 dataset.cite.downloadBtn=Citer l'ensemble de données
 dataset.cite.downloadBtn.xml=EndNote XML
 dataset.cite.downloadBtn.ris=RIS
@@ -1234,7 +1234,7 @@ dataset.keywordDisplay.title=Mot-clé
 dataset.subjectDisplay.title=Sujet
 dataset.contact.tip=Utiliser le bouton de courriel ci-dessus pour communiquer avec cette personne. 
 dataset.asterisk.tip=Les astérisques indiquent les champs obligatoires.
-dataset.message.uploadFiles=Téléverser les fichiers de l'ensemble de données — Vous pouvez glisser-déplacer les fichiers à partir de votre ordinateur vers le widget de téléversement. 
+dataset.message.uploadFiles=Téléverser les fichiers de l'ensemble de données \u2014 Vous pouvez glisser-déplacer les fichiers à partir de votre ordinateur vers le widget de téléversement. 
 dataset.message.editMetadata=Modifier les métadonnées de l'ensemble de données\u00A0: ajouter plus de métadonnées afin de faciliter le repérage de cet ensemble.
 dataset.message.editTerms=Modifier les conditions de l'ensemble de données\u00A0: mettre à jour les conditions d'utilisation de cet ensemble de données.
 dataset.message.locked.editNotAllowedInReview=L'ensemble de données ne peut pas être modifié en raison du verrouillage de l'ensemble de données en révision.
@@ -1258,7 +1258,7 @@ dataset.message.bulkFileDeleteSuccess=Les fichiers sélectionnés ont été supprimé
 datasetVersion.message.deleteSuccess=La version provisoire de cet ensemble de données a été supprimée.
 datasetVersion.message.deaccessionSuccess=La ou les versions sélectionnées ont été retirées.
 dataset.message.deaccessionSuccess=Cet ensemble de données a été retiré.
-dataset.message.validationError=Erreur de validation — Les champs obligatoires ont été omis ou il y a eu une erreur de validation. Veuillez défiler le menu vers le bas pour voir les détails. 
+dataset.message.validationError=Erreur de validation \u2014 Les champs obligatoires ont été omis ou il y a eu une erreur de validation. Veuillez défiler le menu vers le bas pour voir les détails. 
 dataset.message.publishFailure=L'ensemble de données n'a pas pu être publié.
 dataset.message.metadataFailure=Les métadonnées n'ont pas pu être mises à jour.
 dataset.message.filesFailure=Les fichiers n'ont pas pu être téléchargés.
@@ -1268,7 +1268,7 @@ dataset.message.deleteFailure=La version provisoire de cet ensemble de données n
 dataset.message.deaccessionFailure=Cet ensemble de données n'a pas pu être retiré. 
 dataset.message.createFailure=L'ensemble de données n'a pas pu être créé.
 dataset.message.termsFailure=Les conditions de cet ensemble de données n'ont pas pu être mises à jour.
-dataset.message.publicInstall=Accès aux fichiers — Les fichiers sont stockés sur un serveur de stockage accessible publiquement.
+dataset.message.publicInstall=Accès aux fichiers \u2014 Les fichiers sont stockés sur un serveur de stockage accessible publiquement.
 dataset.metadata.publicationDate=Date de publication
 dataset.metadata.publicationDate.tip=La date de publication d'un ensemble de données.
 dataset.metadata.persistentId=Identifiant pérenne de l'ensemble de données
@@ -1292,10 +1292,10 @@ dataset.noValidSelectedFilesForDownload=Le ou les fichiers réservés sélectionnés
 dataset.mixedSelectedFilesForDownload=Le ou les fichiers réservés sélectionnés ne peuvent être téléchargés, car les accès ne vous ont pas été accordés.
 dataset.downloadUnrestricted=Cliquez sur Continuer pour télécharger les fichiers pour lesquels vous avez un accès.
 dataset.requestAccessToRestrictedFiles=Vous pouvez demander l'accès à un ou des fichiers réservés en cliquant sur le bouton «\u00A0Demander l'accès\u00A0».
-dataset.privateurl.infoMessageAuthor=URL privé de l''ensemble de données non publié — Partager en privé cet ensemble de données avant sa publication\u00A0: {0}
-dataset.privateurl.infoMessageReviewer=URL privé de l'ensemble de données non publié — Cet ensemble de données non publié est partagé en privé. Vous ne pourrez pas y accéder lorsque connecté à votre compte Dataverse.
+dataset.privateurl.infoMessageAuthor=URL privé de l''ensemble de données non publié \u2014 Partager en privé cet ensemble de données avant sa publication\u00A0: {0}
+dataset.privateurl.infoMessageReviewer=URL privé de l'ensemble de données non publié \u2014 Cet ensemble de données non publié est partagé en privé. Vous ne pourrez pas y accéder lorsque connecté à votre compte Dataverse.
 dataset.privateurl.header=URL privée de l'ensemble de données non publié
-dataset.privateurl.tip=Utiliser une adresse URL privée pour permettre à ceux qui n''ont pas de compte Dataverse d''accéder à votre ensemble de données non publié. Pour plus d''informations sur la fonctionnalité d''URL privé, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#private-url-for-reviewing-an-unpublished-dataset" title="URL privé pour vérifier un ensemble de données non publié — Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
+dataset.privateurl.tip=Utiliser une adresse URL privée pour permettre à ceux qui n''ont pas de compte Dataverse d''accéder à votre ensemble de données non publié. Pour plus d''informations sur la fonctionnalité d''URL privé, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#private-url-for-reviewing-an-unpublished-dataset" title="URL privé pour vérifier un ensemble de données non publié \u2014 Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
 dataset.privateurl.absent=L'adresse URL privée n'a pas été créée.
 dataset.privateurl.createPrivateUrl=Créer une adresse URL privée
 dataset.privateurl.disablePrivateUrl=Désactiver l'URL privé
@@ -1310,7 +1310,7 @@ file.count={0} {0, choice, 0#Fichiers|1#Fichiers|2#Fichiers}
 file.count.selected={0} {0, choice, 0#Fichiers sélectionnés|1#Fichier sélectionné|2#Fichiers sélectionnés}
 file.selectToAddBtn=Sélectionner les fichiers à ajouter
 file.selectToAdd.tipLimit=La limite de téléversement est de {0} par fichier.
-file.selectToAdd.tipMoreInformation=Pour plus d''informations sur les formats de fichiers pris en charge, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#file-handling-uploading" title="Manipulation et téléversement de fichiers — Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
+file.selectToAdd.tipMoreInformation=Pour plus d''informations sur les formats de fichiers pris en charge, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#file-handling-uploading" title="Manipulation et téléversement de fichiers \u2014 Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
 file.selectToAdd.dragdropMsg=Glisser et déposer les fichiers ici.
 file.createUploadDisabled=Une fois que vous avez sauvegardé votre ensemble de données, vous pouvez téléverser vos données en utilisant le bouton «\u00A0Téléverser des fichiers\u00A0» sur la page de l'ensemble de données. Pour plus d'informations sur les formats de fichiers pris en charge, reportez-vous au guide d'utilisation.
 file.fromDropbox=Téléverser à partir de Dropbox
@@ -1350,10 +1350,10 @@ file.selectedThumbnail=Vignette
 file.selectedThumbnail.tip=La vignette associée au fichier est utilisée comme vignette par défaut pour l'ensemble de données. Cliquez sur le bouton «\u00A0Options avancées\u00A0» d'un autre fichier pour sélectionner ce fichier.
 file.cloudStorageAccess=Accès au stockage infonuagique
 file.cloudStorageAccess.tip=Le nom du conteneur pour cet ensemble de données doit accéder aux fichiers dans le stockage infonuagique.
-file.cloudStorageAccess.help=Pour accéder directement à ces données dans l''environnement infonuagique {2}, utilisez le nom du conteneur dans la case d''accès au stockage infonuagique ci-dessous. Pour en apprendre davantage sur l''environnement infonuagique, consultez la section <a href="{0}/{1}/user/dataset-management.html#cloud-storage" title="Accès au stockage en infonuagique — Guide d''utilisation de Dataverse" target="_blank">accès au stockage infonuagique</a> du guide d''utilisation.
+file.cloudStorageAccess.help=Pour accéder directement à ces données dans l''environnement infonuagique {2}, utilisez le nom du conteneur dans la case d''accès au stockage infonuagique ci-dessous. Pour en apprendre davantage sur l''environnement infonuagique, consultez la section <a href="{0}/{1}/user/dataset-management.html#cloud-storage" title="Accès au stockage en infonuagique \u2014 Guide d''utilisation de Dataverse" target="_blank">accès au stockage infonuagique</a> du guide d''utilisation.
 file.copy=Copier
 file.compute=Calculer
-file.rsyncUpload.info=Veuillez suivre ces étapes pour téléverser vos données. Pour en apprendre davantage sur le processus de téléversement et sur comment préparer vos données, veuillez vous reporter à la section <a href = "{0}/{1}/user/dataset-management.html#file-handling-and-uploading" title = "Manipulation et téléchargement de fichiers — Guide d''utilisation de Dataverse" target ="_ blank">Manipulation et téléchargement de fichiers</a> du guide d''utilisation.
+file.rsyncUpload.info=Veuillez suivre ces étapes pour téléverser vos données. Pour en apprendre davantage sur le processus de téléversement et sur comment préparer vos données, veuillez vous reporter à la section <a href = "{0}/{1}/user/dataset-management.html#file-handling-and-uploading" title = "Manipulation et téléchargement de fichiers \u2014 Guide d''utilisation de Dataverse" target ="_ blank">Manipulation et téléchargement de fichiers</a> du guide d''utilisation.
 file.rsyncUpload.noScriptAvailable=Le script Rsync n'est pas disponible!
 file.rsyncUpload.filesExist=Vous ne pouvez pas téléverser des fichiers supplémentaires dans cet ensemble de données.
 file.rsyncUpload.step1=Assurez-vous que vos données sont stockées dans un seul répertoire. Tous les fichiers de ce répertoire et de ses sous-répertoires seront téléversés dans votre ensemble de données.
@@ -1428,16 +1428,16 @@ file.dataFilesTab.terms.editTermsBtn=Modifier les conditions
 file.dataFilesTab.terms.list.termsOfUse.header=Conditions d'utilisation
 file.dataFilesTab.terms.list.termsOfUse.waiver=Licence accordée
 file.dataFilesTab.terms.list.termsOfUse.waiver.title=La licence permet d'informer les utilisateurs de ce qui leur est permis de faire avec ces données téléchargées. 
-file.dataFilesTab.terms.list.termsOfUse.waiver.txt=licence CC0 — «\u00A0Transfert dans le domaine public\u00A0»
-file.dataFilesTab.terms.list.termsOfUse.waiver.description=Les ensembles de données se verront attribuer par défaut une <a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Transfert dans le domaine public — Creative Commons" target="_blank">licence CC0 — Transfert dans le domaine public</a>. CC0 facilite la réutilisation et l'extensibilité des données de recherche. Nos <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Normes de la communauté Dataverse — Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Si vous ne pouvez accorder une licence CC0, vous pouvez établir des conditions d'utilisation personnalisées pour vos ensembles de données. 
+file.dataFilesTab.terms.list.termsOfUse.waiver.txt=licence CC0 \u2014 «\u00A0Transfert dans le domaine public\u00A0»
+file.dataFilesTab.terms.list.termsOfUse.waiver.description=Les ensembles de données se verront attribuer par défaut une <a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Transfert dans le domaine public \u2014 Creative Commons" target="_blank">licence CC0 \u2014 Transfert dans le domaine public</a>. CC0 facilite la réutilisation et l'extensibilité des données de recherche. Nos <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Normes de la communauté Dataverse \u2014 Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Si vous ne pouvez accorder une licence CC0, vous pouvez établir des conditions d'utilisation personnalisées pour vos ensembles de données. 
 file.dataFilesTab.terms.list.termsOfUse.no.waiver.txt=Aucune licence n'a été sélectionnée pour cet ensemble de données. 
-file.dataFilesTab.terms.list.termsOfUse.waiver.txt.description=Les <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Normes de la communauté Dataverse — Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Veuillez utiliser la référence bibliographique ci-dessus générée par Dataverse.
-file.dataFilesTab.terms.list.termsOfUse.waiver.select.CCO=Oui, appliquer la licence CC0 — «\u00A0Transfert dans le domaine public\u00A0».
-file.dataFilesTab.terms.list.termsOfUse.waiver.select.notCCO=Non, ne pas appliquer la licence CC0 — «\u00A0Transfert dans le domaine public\u00A0».
+file.dataFilesTab.terms.list.termsOfUse.waiver.txt.description=Les <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Normes de la communauté Dataverse \u2014 Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Veuillez utiliser la référence bibliographique ci-dessus générée par Dataverse.
+file.dataFilesTab.terms.list.termsOfUse.waiver.select.CCO=Oui, appliquer la licence CC0 \u2014 «\u00A0Transfert dans le domaine public\u00A0».
+file.dataFilesTab.terms.list.termsOfUse.waiver.select.notCCO=Non, ne pas appliquer la licence CC0 \u2014 «\u00A0Transfert dans le domaine public\u00A0».
 file.dataFilesTab.terms.list.termsOfUse.waiver.select.tip=Voici ce que les utilisateurs finaux verront affiché pour cet ensemble de données.
 file.dataFilesTab.terms.list.termsOfUse.termsOfUse=Conditions d'utilisation
 file.dataFilesTab.terms.list.termsOfUse.termsOfUse.title=Indique la façon dont ces données peuvent être utilisées une fois téléchargées.
-file.dataFilesTab.terms.list.termsOfUse.termsOfUse.description=Si vous n'êtes pas en mesure d'utiliser la licence CC0 pour les ensembles de données, vous pouvez établir des conditions d'utilisation personnalisées. Voici un exemple d'une <a href="https://dataverse.org/best-practices/sample-dua" title="Exemple de licence de données — Dataverse.org" target="_blank">licence de données</a> pour des ensembles de données qui comportent des données anonymisées de sujets humains.
+file.dataFilesTab.terms.list.termsOfUse.termsOfUse.description=Si vous n'êtes pas en mesure d'utiliser la licence CC0 pour les ensembles de données, vous pouvez établir des conditions d'utilisation personnalisées. Voici un exemple d'une <a href="https://dataverse.org/best-practices/sample-dua" title="Exemple de licence de données \u2014 Dataverse.org" target="_blank">licence de données</a> pour des ensembles de données qui comportent des données anonymisées de sujets humains.
 file.dataFilesTab.terms.list.termsOfUse.addInfo=Renseignements supplémentaires
 file.dataFilesTab.terms.list.termsOfUse.addInfo.declaration=Déclaration de confidentialité
 file.dataFilesTab.terms.list.termsOfUse.addInfo.declaration.title=Indique s'il faut signer une déclaration de confidentialité pour avoir accès à une ressource.
@@ -1487,8 +1487,8 @@ file.dataFilesTab.terms.list.guestbook.noAvailable.tip=Aucun registre des visite
 file.dataFilesTab.terms.list.guestbook.clearBtn=Effacer la sélection
 
 file.dataFilesTab.dataAccess=Accès aux données
-file.dataFilesTab.dataAccess.info=Ce fichier de données est accessible via une fenêtre de terminal, en utilisant les commandes ci-dessous. Pour plus d''informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="Téléchargement rsync — Guide d''utilisation de Dataverse" target="_blank">téléchargement rsync</a> du guide d''utilisation.
-file.dataFilesTab.dataAccess.info.draft=Les fichiers de données ne sont pas accessibles tant que la version provisoire de l''ensemble de données n''a pas été publiée. Pour plus d''informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="Téléchargement rsync — Guide d''utilisation de Dataverse" target="_blank">téléchargement rsync</a> du guide d''utilisation.
+file.dataFilesTab.dataAccess.info=Ce fichier de données est accessible via une fenêtre de terminal, en utilisant les commandes ci-dessous. Pour plus d''informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="Téléchargement rsync \u2014 Guide d''utilisation de Dataverse" target="_blank">téléchargement rsync</a> du guide d''utilisation.
+file.dataFilesTab.dataAccess.info.draft=Les fichiers de données ne sont pas accessibles tant que la version provisoire de l''ensemble de données n''a pas été publiée. Pour plus d''informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="Téléchargement rsync \u2014 Guide d''utilisation de Dataverse" target="_blank">téléchargement rsync</a> du guide d''utilisation.
 file.dataFilesTab.dataAccess.local.label=Accès local
 file.dataFilesTab.dataAccess.download.label=Accès au téléchargement
 file.dataFilesTab.dataAccess.verify.label=Vérifier les données
@@ -1596,11 +1596,11 @@ dataset.widgets.notPublished.why.reason2=Permet aux autres de parcourir votre da
 dataset.widgets.notPublished.how.header=Comment utiliser les widgets
 dataset.widgets.notPublished.how.tip1=Pour pouvoir utiliser des widgets, votre dataverse et vos ensembles de données doivent être publiés.
 dataset.widgets.notPublished.how.tip2=Suite à la publication, le code sera disponible sur cette page pour que vous puissiez le copier et l'ajouter à votre site web personnel ou de projet.
-dataset.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l'ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title="Ajouts de widgets Dataverse dans un site web OpenScholar — Guide d''utilisation de Dataverse" target="_blank">ici</a>.
-dataset.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets — Guide d''utilisation de Dataverse" target="_blank">thème et widgets</a> du guide d''utilisation.
+dataset.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l'ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title="Ajouts de widgets Dataverse dans un site web OpenScholar \u2014 Guide d''utilisation de Dataverse" target="_blank">ici</a>.
+dataset.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets \u2014 Guide d''utilisation de Dataverse" target="_blank">thème et widgets</a> du guide d''utilisation.
 dataset.widgets.editAdvanced=Modifier les options avancées
 dataset.widgets.editAdvanced.tip=<strong>Options avancées</strong> – Options supplémentaires pour configurer votre widget sur votre site personnel ou de projet.
-dataset.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour en apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets — Guide d''utilisation de Dataverse" target="_blank">Thème et widgets</a> du guide d''utilisation.
+dataset.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour en apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets \u2014 Guide d''utilisation de Dataverse" target="_blank">Thème et widgets</a> du guide d''utilisation.
 dataset.widgets.citation.txt=Citation de l'ensemble de données
 dataset.widgets.citation.tip=Ajoutez la référence de votre ensemble de données à votre site personnel ou de projet.
 dataset.widgets.datasetFull.txt=Ensemble de données
@@ -1739,16 +1739,16 @@ file.addreplace.error.auth=La clé API n'est pas valide.
 file.addreplace.error.invalid_datafile_tag=Libellé de données tabulaires non valide\u00A0: 
 
 # 500.xhtml
-error.500.page.title=500 — Erreur interne du serveur
-error.500.message=<strong>Erreur interne du serveur</strong> — Une erreur inattendue s'est produite, aucune information supplémentaire n'est disponible. 
+error.500.page.title=500 \u2014 Erreur interne du serveur
+error.500.message=<strong>Erreur interne du serveur</strong> \u2014 Une erreur inattendue s'est produite, aucune information supplémentaire n'est disponible. 
 
 # 404.xhtml
-error.404.page.title=404 — Page non trouvée
-error.404.message=<strong>Page non trouvée</strong> — La page que vous cherchez n'a pas été trouvée. 
+error.404.page.title=404 \u2014 Page non trouvée
+error.404.message=<strong>Page non trouvée</strong> \u2014 La page que vous cherchez n'a pas été trouvée. 
 
 # 403.xhtml
-error.403.page.title=403 — Non autorisé
-error.403.message=<strong>Non autorisé</strong> — Vous n'êtes pas autorisé à voir cette page.
+error.403.page.title=403 \u2014 Non autorisé
+error.403.message=<strong>Non autorisé</strong> \u2014 Vous n'êtes pas autorisé à voir cette page.
 
 # general error - support message
 error.support.message=Si vous pensez qu''il s'agit d''une erreur, veuillez contacter {0} pour obtenir de l''aide.
@@ -1883,7 +1883,7 @@ dataverse.item.required=Obligatoire
 dataverse.item.optional=Facultatif
 dataverse.item.hidden=Information cachée
 dataverse.edit.msg=Modifier le dataverse
-dataverse.edit.detailmsg= — Modifier votre dataverse puis cliquer sur Enregistrer. Les astérisques indiquent les champs obligatoires
+dataverse.edit.detailmsg= \u2014 Modifier votre dataverse puis cliquer sur Enregistrer. Les astérisques indiquent les champs obligatoires
 dataverse.feature.update=Les dataverses en vedette pour ce dataverse ont été mis à jour.
 dataverse.link.select=Vous devez sélectionner un dataverse lié.
 dataverse.link.user=Seuls les utilisateurs authentifiés peuvent lier un dataverse.
@@ -1947,7 +1947,7 @@ dataset.notlinked.msg=Un problème est survenu lors de la liaison de cet ensemble
 theme.validateTagline=Le titre d'appel doit comporter au maximum 140 caractères.
 theme.urlValidate=La validation d'URL a échoué.
 theme.urlValidate.msg=Prière de fournir un URL.
-dataverse.save.failed=Échec de l'enregistrement Dataverse —
+dataverse.save.failed=Échec de l'enregistrement Dataverse \u2014
 
 #LinkValidator.java
 link.tagline.validate=Veuillez entrer un titre d'appel pour le site web qui constituera le texte d'hyperlien.
@@ -1959,7 +1959,7 @@ template.save=Le modèle a été modifié et enregistré.
 
 #GuestbookPage.java
 guestbook.save.fail=La sauvegarde du registre des visiteurs a échoué.
-guestbook.option.msg= — Une question à choix multiples nécessite plusieurs choix de réponses. Veuillez compléter avant d'enregistrer.
+guestbook.option.msg= \u2014 Une question à choix multiples nécessite plusieurs choix de réponses. Veuillez compléter avant d'enregistrer.
 guestbook.create=Le registre des visiteurs a été créé. 
 guestbook.save=Le registre des visiteurs a été modifié et enregistré.
 
@@ -2016,7 +2016,7 @@ page.copy=Copie de
 permission.roleAssignedToOn=Rôle {0} assigné à {1} pour {2}
 permission.cannotAssignRole=Le rôle n''a pu être assigné\u00A0: {0}
 permission.roleRevoked=Attribution de rôle révoquée avec succès
-permission.cannotRevokeRole1=Impossible de révoquer l''attribution de rôle — il vous manque la permission {0}
+permission.cannotRevokeRole1=Impossible de révoquer l''attribution de rôle \u2014 il vous manque la permission {0}
 permission.cannotRevokeRole2=Impossible de révoquer l''attribution de rôle\u00A0: {0}
 permission.roleSave=Le rôle «\u00A0{0}\u00A0» a été sauvegardé
 permission.cannotSaveRole=Impossible de sauvegarder le rôle {0}

--- a/src/main/java/Bundle_fr.properties
+++ b/src/main/java/Bundle_fr.properties
@@ -133,15 +133,15 @@ contact.contact=Personne-ressource
 contact.context.subject.dvobject={0} Personne-ressource\u00A0: {1}
 contact.context.subject.support={0} Demande de soutien\u00A0: {1}
 contact.context.dataverse.intro={0}Vous venez de recevoir le message suivant de {1} via le dataverse hébergé {2} nommé «\u00A0{3}\u00A0»\u00A0:\n\n---\n\n
-contact.context.dataverse.ending=\n\n---\n\n{0}\n{1}\n\nAccéder au dataverse {2}/dataverse/{3}\n\nVous avez reçu ce courriel car vous avez été enregistré en tant que personne-contact pour le dataverse. Si vous pensez qu'il s'agit d'une erreur, veuillez contacter {4} à {5}. Pour répondre directement à la personne qui a envoyé le message, répondez simplement à ce courriel.
+contact.context.dataverse.ending=\n\n---\n\n{0}\n{1}\n\nAccéder au dataverse {2}/dataverse/{3}\n\nVous avez reçu ce courriel car vous avez été enregistré en tant que personne-contact pour le dataverse. Si vous pensez qu''il s''agit d''une erreur, veuillez contacter {4} à {5}. Pour répondre directement à la personne qui a envoyé le message, répondez simplement à ce courriel.
 contact.context.dataverse.noContact=Il n'y a pas d'adresse de contact enregistrée pour ce dataverse. Par conséquent ce message est envoyé à l'adresse du système.\n\n
 contact.context.dataset.greeting.helloFirstLast=Bonjour {0} {1},
 contact.context.dataset.greeting.organization=À l'attention de la personne-contact de l'ensemble de données\u00A0:
-contact.context.dataset.intro={0}\n\nVous venez de recevoir le message suivant de {1} via l'ensemble de données hébergé {2} nommé «\u00A0{3}\u00A0» ({4})\u00A0:\n\n---\n\n
-contact.context.dataset.ending=\n\n---\n\n{0}\n{1}\n\nAccéder à l'ensemble de données {2}/dataset.xhtml?persistentId={3}\n\nVous avez reçu ce courriel car vous avez été enregistré en tant que personne-contact pour l'ensemble de données. Si vous pensez qu'il s'agit d'une erreur, veuillez contacter {4} à {5}. Pour répondre directement à la personne qui a envoyé le message, répondez simplement à ce courriel.
+contact.context.dataset.intro={0}\n\nVous venez de recevoir le message suivant de {1} via l''ensemble de données hébergé {2} nommé «\u00A0{3}\u00A0» ({4})\u00A0:\n\n---\n\n
+contact.context.dataset.ending=\n\n---\n\n{0}\n{1}\n\nAccéder à l''ensemble de données {2}/dataset.xhtml?persistentId={3}\n\nVous avez reçu ce courriel car vous avez été enregistré en tant que personne-contact pour l''ensemble de données. Si vous pensez qu''il s''agit d''une erreur, veuillez contacter {4} à {5}. Pour répondre directement à la personne qui a envoyé le message, répondez simplement à ce courriel.
 contact.context.dataset.noContact=Il n'y a pas d'adresse de contact enregistrée pour ce ensemble de données. Par conséquent ce message est envoyé à l'adresse du système.\n\n---\n\n
-contact.context.file.intro={0}\n\nVous venez de recevoir le message suivant de {1} via le fichier hébergé {2} nommé «\u00A0{3}\u00A0» provenant de l'ensemble de données nommé «\u00A0{4}\u00A0» ({5})\u00A0:\n\n---\n\n
-contact.context.file.ending=\n\n---\n\n{0}\n{1}\n\nAccéder au fichier {2}/file.xhtml?fileId={3}\n\nVous avez reçu ce courriel car vous avez été enregistré en tant que personne-contact pour l'ensemble de données. Si vous pensez qu'il s'agit d'une erreur, veuillez contacter {4} à {5}. Pour répondre directement à la personne qui a envoyé le message, répondez simplement à ce courriel.
+contact.context.file.intro={0}\n\nVous venez de recevoir le message suivant de {1} via le fichier hébergé {2} nommé «\u00A0{3}\u00A0» provenant de l''ensemble de données nommé «\u00A0{4}\u00A0» ({5})\u00A0:\n\n---\n\n
+contact.context.file.ending=\n\n---\n\n{0}\n{1}\n\nAccéder au fichier {2}/file.xhtml?fileId={3}\n\nVous avez reçu ce courriel car vous avez été enregistré en tant que personne-contact pour l''ensemble de données. Si vous pensez qu''il s''agit d'une erreur, veuillez contacter {4} à {5}. Pour répondre directement à la personne qui a envoyé le message, répondez simplement à ce courriel.
 contact.context.support.intro={0},\n\nLe message suivant a été envoyé depuis {1}.\n\n---\n\n
 contact.context.support.ending=\n\n---\n\nMessage envoyé depuis le formulaire de demande de soutien.
 
@@ -165,37 +165,37 @@ wasReturnedByReviewer=a été retourné par l'intendant des données de
 toReview=N'oubliez pas de les publier ou de les renvoyer au collaborateur!
 worldMap.added=Les données d'une couche WorldMap ont été ajoutées à l'ensemble de données.
 # Bundle file editors, please note that "notification.welcome" is used in a unit test.
-notification.welcome=Bienvenue dans le {0}! Commencez dès maintenant en ajoutant ou encore en recherchant des données. Des questions? Consultez le\u00A0: {1}. Vous voulez faire l'essai des composantes de Dataverse? Essayez notre {2}.  N'oubliez pas de vérifier que vous avez bien reçu votre courriel d'invitation afin que nous puissions valider votre adresse.
+notification.welcome=Bienvenue dans le {0}! Commencez dès maintenant en ajoutant ou encore en recherchant des données. Des questions? Consultez le\u00A0: {1}. Vous voulez faire l''essai des composantes de Dataverse? Essayez notre {2}.  N''oubliez pas de vérifier que vous avez bien reçu votre courriel d''invitation afin que nous puissions valider votre adresse.
 notification.demoSite=Site de démonstration
-notification.requestFileAccess=Demande d'accès pour l'ensemble de données\u00A0: {0}.
-notification.grantFileAccess=Accès accordé pour les fichiers de l'ensemble de données\u00A0: {0}.
-notification.rejectFileAccess=Demande d'accès refusée pour les fichiers de l'ensemble de données\u00A0: {0}.
-notification.createDataverse={0}  a été créé dans {1}. Pour savoir ce que vous pouvez faire avec votre dataverse, consultez le {2}.
-notification.dataverse.management.title=Administration de Dataverse - Guide d'utilisation de Dataverse
-notification.createDataset={0}  a été créé dans {1}. Pour savoir ce que vous pouvez faire avec votre ensemble de données, consultez le {2}.
-notification.dataset.management.title=Administration des ensembles de données - Guide d'utilisation pour les ensembles de données
-notification.wasSubmittedForReview={0} a été soumis pour vérification avant publication dans {1}. N'oubliez pas de le publier ou de le renvoyer au collaborateur\!
-notification.wasReturnedByReviewer={0} a été retourné par l'intendant des données de {1}.
+notification.requestFileAccess=Demande d'accès pour l''ensemble de données\u00A0: {0}.
+notification.grantFileAccess=Accès accordé pour les fichiers de l''ensemble de données\u00A0: {0}.
+notification.rejectFileAccess=Demande d''accès refusée pour les fichiers de l''ensemble de données\u00A0: {0}.
+notification.createDataverse={0} a été créé dans {1}. Pour savoir ce que vous pouvez faire avec votre dataverse, consultez le {2}.
+notification.dataverse.management.title=Administration de Dataverse — Guide d'utilisation de Dataverse
+notification.createDataset={0} a été créé dans {1}. Pour savoir ce que vous pouvez faire avec votre ensemble de données, consultez le {2}.
+notification.dataset.management.title=Administration des ensembles de données — Guide d'utilisation pour les ensembles de données
+notification.wasSubmittedForReview={0} a été soumis pour vérification avant publication dans {1}. N''oubliez pas de le publier ou de le renvoyer au collaborateur\!
+notification.wasReturnedByReviewer={0} a été retourné par l''intendant des données de {1}.
 notification.wasPublished={0} a été publié dans {1}.
-notification.worldMap.added={0}, cet ensemble de données dispose maintenant d'une couche de données WorldMap.
+notification.worldMap.added={0}, cet ensemble de données dispose maintenant d''une couche de données WorldMap.
 notification.maplayer.deletefailed=Impossible de supprimer la couche cartographique associée au fichier à accès restreint {0} provenant de WorldMap. Essayez de nouveau, ou contactez le soutien WorldMap et/ou Dataverse. (Ensemble de données\u00A0: {1})
 notification.generic.objectDeleted=Le dataverse, l'ensemble de données ou le fichier visé par cet avis a été supprimé. 
 notification.access.granted.dataverse=Le rôle {0} vous a été accordé pour {1}.
 notification.access.granted.dataset=Le rôle {0} vous a été accordé pour {1}.
 notification.access.granted.datafile=Le rôle {0} vous a été accordé pour un fichier dans {1}.
-notification.access.granted.fileDownloader.additionalDataverse={0} Vous avez maintenant accès à tous les fichiers en accès réservé ou non réservé publiés dans ce dataverse. 
-notification.access.granted.fileDownloader.additionalDataset={0} Vous avez maintenant accès à tous les fichiers réservés ou non réservés qui ont été publiés dans cet ensemble de données.
+notification.access.granted.fileDownloader.additionalDataverse={0} Vous avez maintenant accès à tous les fichiers (en accès réservé ou non) publiés dans ce dataverse. 
+notification.access.granted.fileDownloader.additionalDataset={0} Vous avez maintenant accès à tous les fichiers (en accès réservés ou non) publiés dans cet ensemble de données.
 notification.access.revoked.dataverse=Votre rôle dans {0} a été retiré.
 notification.access.revoked.dataset=Votre rôle dans {0} a été retiré.
 notification.access.revoked.datafile=Votre rôle dans {0} a été retiré.
-notification.checksumfail=La validation de la somme de contrôle pour l'ensemble de données {0} a échoué pour un ou plus d'un fichier(s) téléversé(s). Veuillez relancer le script de téléversement. Si le problème persiste, prière de consulter le service de soutien.
-notification.mail.import.filesystem=L'ensemble de données {2} ({0}/dataset.xhtml?persistentId={1}) a bien été téléversé et vérifié.
-notification.import.filesystem=L'ensemble de données <a href="/dataset.xhtml?persistentId={0}" title="{1}">{1}</a> a bien été téléversé et vérifié.
-notification.import.checksum=<a href="/dataset.xhtml?persistentId={0}" title="{1}">{1}</a>, l'ensemble de données a ajouté les sommes de contrôle des fichiers par l'entremise d'un traitement en lot.
+notification.checksumfail=La validation de la somme de contrôle pour l''ensemble de données {0} a échoué pour un ou plus d''un fichier(s) téléversé(s). Veuillez relancer le script de téléversement. Si le problème persiste, prière de consulter le service de soutien.
+notification.mail.import.filesystem=L''ensemble de données {2} ({0}/dataset.xhtml?persistentId={1}) a bien été téléversé et vérifié.
+notification.import.filesystem=L''ensemble de données <a href="/dataset.xhtml?persistentId={0}" title="{1}">{1}</a> a bien été téléversé et vérifié.
+notification.import.checksum=<a href="/dataset.xhtml?persistentId={0}" title="{1}">{1}</a>, l''ensemble de données a ajouté les sommes de contrôle des fichiers par l''entremise d''un traitement en lot.
 removeNotification=Supprimer l'avis
 groupAndRoles.manageTips=Vous pouvez gérer tous les groupes dont vous êtes membre et les rôles qui vous ont été confiés et y avoir accès.
 user.signup.tip=Pourquoi se créer un compte Dataverse? De façon à pouvoir créer votre propre dataverse, le personnaliser, y ajouter des ensembles de données, ou encore pour demander l'accès à des fichiers à accès réservé. 
-user.signup.otherLogInOptions.tip=<a href="/loginpage.xhtml" title="Dataverse - Se connecter">Voir les autres options de connexion.</a>
+user.signup.otherLogInOptions.tip=<a href="/loginpage.xhtml" title="Dataverse — Se connecter">Voir les autres options de connexion.</a>
 user.username.illegal.tip=Votre nom d'utilisateur doit compter entre 2 et 60\u00A0caractères et vous pouvez utiliser les lettres a à z, les chiffres 0 à 9 et le caractère souligné «\u00A0_\u00A0».
 user.username=Nom d'utilisateur
 user.username.taken=Ce nom d'utilisateur est déjà pris.
@@ -226,7 +226,7 @@ user.updatePassword.warning=Les exigences relatives au mot de passe et les condi
 user.updatePassword.password={0}
 user.password=Mot de passe
 user.newPassword=Nouveau mot de passe
-authenticationProvidersAvailable.tip={0}Il n'y a aucun système d'authentification actif{1}Si vous êtes administrateur système, veuillez en autoriser un au moyen de l'API.{2}Si vous n'êtes pas administrateur système, veuillez communiquer avec celui de votre établissement. 
+authenticationProvidersAvailable.tip={0}Il n''y a aucun système d''authentification actif{1}Si vous êtes administrateur système, veuillez en autoriser un au moyen de l''API.{2}Si vous n''êtes pas administrateur système, veuillez communiquer avec celui de votre établissement. 
 
 passwdVal.passwdReq.title=Votre mot de passe doit contenir\u00A0:
 passwdVal.passwdReq.goodStrength =Les mots de passe d'un minimum de {0} caractères sont exempts de tout autre exigence
@@ -238,7 +238,7 @@ passwdVal.passwdReq.dictionaryWords =Des mots du dictionnaire
 passwdVal.passwdReq.unknownPasswordRule =Inconnu, contactez votre administrateur
 #printf syntax used to pass to passay library
 passwdVal.expireRule.errorCode =EXPIRÉ
-passwdVal.expireRule.errorMsg =Le mot de passe date de plus de %1$s jours et est expiré.
+passwdVal.expireRule.errorMsg =Le mot de passe date de plus de %1$s jour(s) et est expiré.
 passwdVal.goodStrengthRule.errorMsg =Remarque\u00A0: les mots de passe d'une longueur de %1$s caractères ou plus restent toujours valides.
 passwdVal.goodStrengthRule.errorCode =PEU SÛR
 passwdVal.passwdReset.resetLinkTitle =Lien pour la réinitialisation du mot de passe
@@ -255,7 +255,7 @@ login.System=Système d'authentification
 login.forgot.text=Mot de passe oublié?
 login.builtin=Compte Dataverse
 login.institution=Compte institutionnel
-login.institution.blurb=Connectez-vous ou inscrivez-vous avec votre compte institutionnel &mdash; <a href="{0}/{1}/user/account.html" target="_blank">En apprendre davantage</a>.
+login.institution.blurb=Connectez-vous ou inscrivez-vous avec votre compte institutionnel — <a href="{0}/{1}/user/account.html" target="_blank">En apprendre davantage</a>.
 login.institution.support.beforeLink=Vous quittez votre établissement? Prière de contacter
 login.institution.support.afterLink=pour obtenir de l'aide.
 login.builtin.credential.usernameOrEmail=Nom d'utilisateur/courriel
@@ -269,19 +269,19 @@ login.button=Connectez-vous avec {0}
 login.button.orcid=Créez ou connectez-vous avec votre ORCID iD
 # authentication providers
 auth.providers.title=Autres options
-auth.providers.tip=Vous pouvez convertir un compte Dataverse pour utiliser l'une des options ci-dessus. <a href="{0}/{1}/user/account.html" target="_blank">En apprendre davantage</a>.
+auth.providers.tip=Vous pouvez convertir un compte Dataverse pour utiliser l''une des options ci-dessus. <a href="{0}/{1}/user/account.html" target="_blank">En apprendre davantage</a>.
 auth.providers.title.builtin=Nom d'utilisateur/Courriel
 auth.providers.title.shib=Votre établissement
 auth.providers.title.orcid=ORCID
 auth.providers.title.google=Google
 auth.providers.title.github=GitHub
-auth.providers.blurb=Connectez-vous ou inscrivez-vous avec votre compte {0} &mdash; <a href="{1}/{2}/user/account.html" target="_blank">En apprendre davantage</a>. Vous éprouvez des problèmes? Veuillez contacter {3} pour obtenir de l'aide.
+auth.providers.blurb=Connectez-vous ou inscrivez-vous avec votre compte {0} — <a href="{1}/{2}/user/account.html" target="_blank">En apprendre davantage</a>. Vous éprouvez des problèmes? Veuillez contacter {3} pour obtenir de l''aide.
 auth.providers.persistentUserIdName.orcid=ORCID iD
 auth.providers.persistentUserIdName.github=Identifiant GitHub
 auth.providers.persistentUserIdTooltip.orcid=ORCID fournit un identifiant numérique pérenne qui vous distingue des autres chercheurs.
 auth.providers.persistentUserIdTooltip.github=GitHub attribue un identifiant unique à chaque utilisateur.
 auth.providers.orcid.insufficientScope=Dataverse n'a pas reçu l'autorisation de lire les données utilisateur de ORCID.
-auth.providers.orcid.helpmessage1=ORCID est une initiative communautaire, ouverte et sans but lucratif visant à fournir un registre d'identifiants uniques de chercheurs ainsi qu'une méthode transparente pour lier les activités et produits de la recherche à ces identifiants. ORCID est unique dans sa capacité à atteindre les intervenants de toutes disciplines, secteurs de recherche et frontières nationales confondus ainsi que de coopérer avec d'autres systèmes d'identifiants. Pour en savoir davantage visitez <a href="https://orcid.org/about" target="_blank">orcid.org/about</a>.
+auth.providers.orcid.helpmessage1=ORCID est une initiative communautaire, ouverte et sans but lucratif visant à fournir un registre d'identifiants uniques de chercheurs ainsi qu'une méthode transparente pour lier les activités et produits de la recherche à ces identifiants. ORCID est unique dans sa capacité à atteindre les intervenants de toutes disciplines, secteurs de recherche et frontières nationales confondus ainsi que de coopérer avec d'autres systèmes d'identifiants. Pour en apprendre davantage visitez <a href="https://orcid.org/about" target="_blank">orcid.org/about</a>.
 auth.providers.orcid.helpmessage2=Ce dépôt utilise votre ORCID iD pour l'authentification (vous n'avez donc pas besoin d'une autre combinaison nom d'utilisateur / mot de passe). Le fait que votre compte ORCID soit associé à vos ensembles de données facilite également la recherche des ensembles de données que vous avez publiés.
 
 # Friendly AuthenticationProvider names
@@ -308,25 +308,25 @@ shib.btn.convertAccount=Convertir le compte
 shib.btn.createAccount=Créer le compte
 shib.askToConvert=Désirez-vous convertir votre compte Dataverse de façon à utiliser dorénavant vos informations de connexion institutionnelle afin de vous connecter?
 # Bundle file editors, please note that "shib.welcomeExistingUserMessage" is used in a unit test
-shib.welcomeExistingUserMessage=Vos informations de connection institutionnelle pour {0} comprennent une adresse courriel déjà utilisée pour un compte Dataverse existant. En entrant ici-bas votre mot de passe Dataverse actuel, votre compte Dataverse pourra être converti de façon à ce que vous puissiez dorénavant utiliser votre compte institutionnel. Suite à cette conversion, vous n'aurez plus qu'à utiliser votre compte institutionnel pour pouvoir vous connecter. 
+shib.welcomeExistingUserMessage=Vos informations de connexion institutionnelle pour {0} comprennent une adresse courriel déjà utilisée pour un compte Dataverse existant. En entrant ici-bas votre mot de passe Dataverse actuel, votre compte Dataverse pourra être converti de façon à ce que vous puissiez dorénavant utiliser votre compte institutionnel. Suite à cette conversion, vous n''aurez plus qu''à utiliser votre compte institutionnel pour pouvoir vous connecter. 
 # Bundle file editors, please note that "shib.welcomeExistingUserMessageDefaultInstitution" is used in a unit test
 shib.welcomeExistingUserMessageDefaultInstitution=votre établissement
 shib.dataverseUsername=Nom d'utilisateur Dataverse
 shib.currentDataversePassword=Mot de passe Dataverse actuel
 shib.accountInformation=Renseignements sur le compte
 shib.offerToCreateNewAccount=Cette information est fournie par votre établissement et sera employée pour créer votre compte Dataverse.
-shib.passwordRejected=<strong>Erreur de validation</strong> - Votre compte peut uniquement être converti si vous indiquez le bon mot de passe pour votre compte existant.
+shib.passwordRejected=<strong>Erreur de validation</strong> — Votre compte peut uniquement être converti si vous indiquez le bon mot de passe pour votre compte existant.
 
 # oauth2/firstLogin.xhtml
 oauth2.btn.convertAccount=Convertir le compte existant
 oauth2.btn.createAccount=Créer un nouveau compte
 oauth2.askToConvert=Désirez-vous convertir votre compte Dataverse de façon à toujours utiliser votre compte institutionnel? 
-oauth2.welcomeExistingUserMessage=Votre compte institutionnel {0} correspond à une adresse courriel déjà utilisée pour un compte Dataverse. En entrant votre mot de passe actuel de Dataverse ci-dessous, votre compte Dataverse existant peut être converti pour utiliser votre compte institutionnel à la place. Suite à la conversion vous n'aurez plus qu'à utiliser votre compte institutionnel.
+oauth2.welcomeExistingUserMessage=Votre compte institutionnel {0} correspond à une adresse courriel déjà utilisée pour un compte Dataverse. En entrant votre mot de passe actuel de Dataverse ci-dessous, votre compte Dataverse existant peut être converti pour utiliser votre compte institutionnel à la place. Suite à la conversion vous n''aurez plus qu''à utiliser votre compte institutionnel.
 oauth2.welcomeExistingUserMessageDefaultInstitution=votre établissement
 oauth2.dataverseUsername=Nom d'utilisateur Dataverse
 oauth2.currentDataversePassword=Mot de passe Dataverse actuel
 oauth2.chooseUsername=Nom d'utilisateur\u00A0: 
-oauth2.passwordRejected=<strong>Erreur de validation</strong> - Nom d'utilisateur ou mot de passe incorrect.
+oauth2.passwordRejected=<strong>Erreur de validation</strong> — Nom d'utilisateur ou mot de passe incorrect.
 # oauth2.newAccount.title=Création de compte
 oauth2.newAccount.welcomeWithName=Bienvenue dans Dataverse, {0}
 oauth2.newAccount.welcomeNoName=Bienvenue dans Dataverse
@@ -335,8 +335,8 @@ oauth2.newAccount.welcomeNoName=Bienvenue dans Dataverse
 oauth2.newAccount.suggestedEmails=Adresses de courriel suggérées\u00A0:
 oauth2.newAccount.username=Nom d'utilisateur
 oauth2.newAccount.username.tip=Ce nom d'utilisateur sera votre identifiant unique en tant qu'utilisateur Dataverse.
-oauth2.newAccount.explanation=Cette information est fournie par {0} et sera utilisée pour créer votre compte {1}. Pour vous connecter à nouveau, vous devrez utiliser l'option de connexion {0}.
-oauth2.newAccount.suggestConvertInsteadOfCreate=Si vous avez déjà un compte {0}, vous devrez <a href="/oauth2/convert.xhtml"> convertir votre compte</a>.
+oauth2.newAccount.explanation=Cette information est fournie par {0} et sera utilisée pour créer votre compte {1}. Pour vous connecter à nouveau, vous devrez utiliser l''option de connexion {0}.
+oauth2.newAccount.suggestConvertInsteadOfCreate=Si vous avez déjà un compte {0}, vous devrez <a href="/oauth2/convert.xhtml">convertir votre compte</a>.
 # oauth2.newAccount.tabs.convertAccount=Convertir un compte existant
 oauth2.newAccount.buttons.convertNewAccount=Convertir un compte
 oauth2.newAccount.emailTaken=Adresse courriel déjà prise. Envisagez plutôt de de fusionner le compte correspondant.
@@ -347,21 +347,21 @@ oauth2.newAccount.emailInvalid=Adresse courriel non valide.
 
 # oauth2/convert.xhtml
 # oauth2.convertAccount.title=Conversion de compte
-oauth2.convertAccount.explanation=Entrez votre nom d'utilisateur {0} ou encore votre nom d'utilisateur et votre mot de passe pour convertir votre compte à l'option de connexion {1}. <a href="{2}/{3}/user/account.html" target="_blank">En apprendre davantage</a> à propos de la conversion de votre compte.
+oauth2.convertAccount.explanation=Entrez votre nom d''utilisateur {0} ou votre courriel ainsi que votre mot de passe pour convertir votre compte à l''option de connexion {1}. <a href="{2}/{3}/user/account.html" target="_blank">En apprendre davantage</a> à propos de la conversion de votre compte.
 oauth2.convertAccount.username=Nom d'utilisateur existant
 oauth2.convertAccount.password=Mot de passe
-oauth2.convertAccount.authenticationFailed=Authentification échouée - Nom d'utilisateur ou mot de passe incorrect.
+oauth2.convertAccount.authenticationFailed=Authentification échouée — Nom d'utilisateur ou mot de passe incorrect.
 oauth2.convertAccount.buttonTitle=Convertir un compte
 oauth2.convertAccount.success=Votre compte Dataverse est maintenant associé à votre compte {0}.
 
 # oauth2/callback.xhtml
 oauth2.callback.page.title=Rappel OAuth
-oauth2.callback.message=<strong>Erreur d'authentification</strong> - Dataverse n'a pas pu authentifier votre connexion ORCID. Assurez-vous d'autoriser votre compte ORCID à se connecter à Dataverse. Pour plus de détails sur les informations demandées, voir la section <a href="{0}/{1}/user/account.html#orcid-log-in" title="Authentification ORCID - Guide d'utilisation de Dataverse" target="_blank">authentification ORCID</a> du guide d'utilisation.
+oauth2.callback.message=<strong>Erreur d''authentification</strong> — Dataverse n''a pas pu authentifier votre connexion ORCID. Assurez-vous d''autoriser votre compte ORCID à se connecter à Dataverse. Pour plus de détails sur les informations demandées, voir la section <a href="{0}/{1}/user/account.html#orcid-log-in" title="Authentification ORCID — Guide d''utilisation de Dataverse" target="_blank">authentification ORCID</a> du guide d''utilisation.
 
 # tab on dataverseuser.xhtml
 apitoken.title=Jeton API
-apitoken.message=Votre jeton API sera affiché ci-après une fois qu'il aura été créé. Consultez notre {0}guide API{1} pour obtenir plus de détails sur comment utiliser votre jeton API avec les API de Dataverse 
-apitoken.notFound=Le jeton API pour {0} n'a pas été créé.
+apitoken.message=Votre jeton API sera affiché ci-après une fois qu''il aura été créé. Consultez notre {0}guide API{1} pour obtenir plus de détails sur comment utiliser votre jeton API avec les API de Dataverse 
+apitoken.notFound=Le jeton API pour {0} n''a pas été créé.
 apitoken.generateBtn=Créer le jeton
 apitoken.regenerateBtn=Créer de nouveau le jeton
 
@@ -378,7 +378,7 @@ dashboard.card.harvestingserver.status=Statut
 dashboard.card.harvestingserver.sets={0, choice, 0#Ensembles|1#Ensemble|2#Ensembles}
 dashboard.card.harvestingserver.btn.manage=Gestion du serveur
 dashboard.card.metadataexport.header=Exportation des métadonnées
-dashboard.card.metadataexport.message=L'exportation des métadonnées de l'ensemble de données n'est disponible que via l'API de {0}. Pour en savoir davantage, consultez le {1}Guide API{2} du {0}.
+dashboard.card.metadataexport.message=L''exportation des métadonnées de l''ensemble de données n''est disponible que via l''API de {0}. Pour en apprendre davantage, consultez le {1}Guide API{2} du {0}.
 
 #harvestclients.xhtml
 harvestclients.title=Administration du moissonnage de clients
@@ -390,7 +390,7 @@ harvestclients.noClients.why.reason2=Les notices de métadonnées moissonnées sont
 harvestclients.noClients.how.header=Comment effectuer le moissonnage
 harvestclients.noClients.how.tip1=Afin de pouvoir moissonner des métadonnées, un <i>client de moissonnage</i> doit être défini et paramétré pour chacun des dépôts distants. Veuillez noter que pour définir un client, vous devrez sélectionner un dataverse local déjà existant, lequel hébergera les ensembles de données moissonnés.
 harvestclients.noClients.how.tip2=Les notices récoltées peuvent être synchronisées avec le dépôt d'origine à l'aide de mises à jour incrémentielles programmées, par exemple, quotidiennes ou hebdomadaires. Alternativement, les moissonnages peuvent être exécutés à la demande, à partir de cette page ou via l'API REST.
-harvestclients.noClients.getStarted=Pour commencer, cliquez sur le bouton «\u00A0Ajouter un client\u00A0» ci-dessus. Pour en savoir davantage sur le moissonnage, consultez la section <a href="{0}/{1}/user/index.html#index" title="Moissonnage - Guide d'utilisation de Dataverse" target="_blank">moissonnage</a> du guide d'utilisation.
+harvestclients.noClients.getStarted=Pour commencer, cliquez sur le bouton «\u00A0Ajouter un client\u00A0» ci-dessus. Pour en apprendre davantage sur le moissonnage, consultez la section <a href="{0}/{1}/user/index.html#index" title="Moissonnage — Guide d''utilisation de Dataverse" target="_blank">moissonnage</a> du guide d''utilisation.
 harvestclients.btn.add=Ajouter un client
 harvestclients.tab.header.name=Alias
 harvestclients.tab.header.url=Adresse URL
@@ -404,8 +404,8 @@ harvestclients.tab.header.action.btn.delete.dialog.header=Supprimer le client de
 harvestclients.tab.header.action.btn.delete.dialog.warning=Voulez-vous vraiment supprimer le client de moissonnage «\u00A0{0}\u00A0»? La suppression du client supprimera tous les ensembles de données récoltés à partir de ce serveur distant.
 harvestclients.tab.header.action.btn.delete.dialog.tip=Veuillez noter que cette opération peut prendre un certain temps à effectuer en fonction du nombre d'ensembles de données récoltés.
 harvestclients.tab.header.action.delete.infomessage=La suppression du client de moissonnage est lancée. Notez que cela peut prendre un certain temps en fonction de la quantité de contenu récolté.
-harvestclients.actions.runharvest.success=Lancement réussi d'un moissonnage asynchrone pour le client «\u00A0{0}\u00A0». Veuillez recharger la page pour vérifier les résultats de la récolte.
-harvestclients.newClientDialog.step1=Étape 1 de 4 - Renseignements au sujet du client
+harvestclients.actions.runharvest.success=Lancement réussi d''un moissonnage asynchrone pour le client «\u00A0{0}\u00A0». Veuillez recharger la page pour vérifier les résultats de la récolte.
+harvestclients.newClientDialog.step1=Étape 1 de 4 — Renseignements au sujet du client
 harvestclients.newClientDialog.title.new=Définir un client de moissonnage
 harvestclients.newClientDialog.help=Configurer un client pour moissonner le contenu d'un serveur distant
 harvestclients.newClientDialog.nickname=Alias
@@ -431,7 +431,7 @@ harvestclients.newClientDialog.dataverse.menu.enterName=Saisir l'alias du datave
 harvestclients.newClientDialog.dataverse.menu.header=Nom du dataverse (affiliation), alias
 harvestclients.newClientDialog.dataverse.menu.invalidMsg=Aucun résultat
 harvestclients.newClientDialog.dataverse.required=Vous devez sélectionner un dataverse existant pour ce client de moissonnage.
-harvestclients.newClientDialog.step2=Étape 2 de 4 - Format
+harvestclients.newClientDialog.step2=Étape 2 de 4 — Format
 harvestclients.newClientDialog.oaiSets=Ensemble OAI
 harvestclients.newClientDialog.oaiSets.tip=Ensembles moissonnables offerts par ce serveur OAI.
 harvestclients.newClientDialog.oaiSets.noset=Aucun
@@ -440,7 +440,7 @@ harvestclients.newClientDialog.oaiSets.helptext.noset=Ce serveur OAI ne prend pa
 harvestclients.newClientDialog.oaiMetadataFormat=Format des métadonnées
 harvestclients.newClientDialog.oaiMetadataFormat.tip=Formats de métadonnées offerts par le serveur distant.
 harvestclients.newClientDialog.oaiMetadataFormat.required=Veuillez sélectionner le format de métadonnées à utiliser pour le moissonnage de ce dépôt.
-harvestclients.newClientDialog.step3=Étape 3 de 4 - Planifier
+harvestclients.newClientDialog.step3=Étape 3 de 4 — Planifier
 harvestclients.newClientDialog.schedule=Périodicité
 harvestclients.newClientDialog.schedule.tip=Programmer le moissonnage pour qu'il s'exécute automatiquement de façon quotidienne ou hebdomadaire.
 harvestclients.newClientDialog.schedule.time.none.helptext=Ne pas spécifier de périodicité de moissonnage de sorte que l'exécution se fera sur demande seulement.
@@ -454,7 +454,7 @@ harvestclients.newClientDialog.schedule.time.pm=p.m.
 harvestclients.newClientDialog.schedule.time.helptext=L'horaire programmé se réfère à votre heure locale.
 harvestclients.newClientDialog.btn.create=Créer un client
 harvestclients.newClientDialog.success=Le client de moissonnage «\u00A0{0}\u00A0» a bien été créé.
-harvestclients.newClientDialog.step4=Étape 4 de 4 - Affichage
+harvestclients.newClientDialog.step4=Étape 4 de 4 — Affichage
 harvestclients.newClientDialog.harvestingStyle=Type de dépôt
 harvestclients.newClientDialog.harvestingStyle.tip=Type du dépôt distant.
 harvestclients.newClientDialog.harvestingStyle.helptext=Sélectionnez le type de dépôt qui décrit le mieux ce serveur distant afin d'appliquer correctement les règles de formatage et de style aux métadonnées récoltées lors de leur affichage dans les résultats de recherche. Notez qu'une sélection incorrecte du type de dépôt distant peut entraîner l'affichage incomplet des entrées dans les résultats de recherche causant ainsi une impossibilité de rediriger l'utilisateur vers le dépôt source des données.
@@ -470,7 +470,7 @@ harvestclients.newClientDialog.title.edit=Modifier le groupe {0}
 
 #harvestset.xhtml
 harvestserver.title=Administration du serveur de moissonnage
-harvestserver.toptip=- Définir les collections d'ensembles de données locaux qui seront disponibles pour le moissonnage par les clients distants.
+harvestserver.toptip=— Définir les collections d'ensembles de données locaux qui seront disponibles pour le moissonnage par les clients distants.
 harvestserver.service.label=Serveur OAI
 harvestserver.service.enabled=Activé
 harvestserver.service.disabled=Désactivé
@@ -482,8 +482,8 @@ harvestserver.noSets.why.reason1=Le moissonnage consiste à échanger des métadonn
 harvestserver.noSets.why.reason2=Seuls les ensembles de données publiés et non restreints de votre Dataverse peuvent être moissonnés. Les clients distants maintiennent normalement leurs enregistrements synchronisés grâce à des mises à jour incrémentielles programmées, quotidiennes ou hebdomadaires, réduisant ainsi la charge sur votre serveur. Notez que seules les métadonnées sont moissonnées. Les moissonneurs distants ne tentent généralement pas de télécharger eux-mêmes les fichiers de données.
 harvestserver.noSets.how.header=Comment activer un serveur de moissonnage?
 harvestserver.noSets.how.tip1=Le serveur de moissonnage peut être activé ou désactivé à partir de cette page. 
-harvestserver.noSets.how.tip2=Une fois le service activé, vous pouvez définir des collections d'ensembles de données locaux qui seront disponibles pour les moissonneurs distants sous <i>Ensembles OAI</i>. Les ensembles sont définis par des requêtes de recherche (par exemple, authorName:king; ou parentId:1234 - pour sélectionner tous les ensembles de données appartenant au dataverse spécifié; ou dsPersistentId:"doi:1234/" pour sélectionner tous les ensembles de données avec l'identifiant perenne spécifié). Consultez la section sur l'API de recherche du guide d'utilisation de Dataverse pour plus d'informations sur les requêtes de recherche.  
-harvestserver.noSets.getStarted=Pour commencer, activez le serveur OAI et cliquez sur le bouton «\u00A0Ajouter un ensemble (set)\u00A0». Pour en savoir plus sur le moissonnage, consultez la section  <a href="{0}/{1}/user/index.html#index" title="Moissonnage - Guide d'utilisation de Dataverse" target="_blank">moissonnage</a> du guide d'utilisation.
+harvestserver.noSets.how.tip2=Une fois le service activé, vous pouvez définir des collections d'ensembles de données locaux qui seront disponibles pour les moissonneurs distants sous <i>Ensembles OAI</i>. Les ensembles sont définis par des requêtes de recherche (par exemple, authorName:king; ou parentId:1234 — pour sélectionner tous les ensembles de données appartenant au dataverse spécifié; ou dsPersistentId:"doi:1234/" pour sélectionner tous les ensembles de données avec l'identifiant perenne spécifié). Consultez la section sur l'API de recherche du guide d'utilisation de Dataverse pour plus d'informations sur les requêtes de recherche.  
+harvestserver.noSets.getStarted=Pour commencer, activez le serveur OAI et cliquez sur le bouton «\u00A0Ajouter un ensemble (set)\u00A0». Pour en apprendre plus sur le moissonnage, consultez la section  <a href="{0}/{1}/user/index.html#index" title="Moissonnage — Guide d''utilisation de Dataverse" target="_blank">moissonnage</a> du guide d''utilisation.
 harvestserver.btn.add=Ajouter un ensemble (set)
 harvestserver.tab.header.spec=setSpec OAI (identifiant OAI de l'ensemble)
 harvestserver.tab.header.description=Description
@@ -493,11 +493,11 @@ harvestserver.tab.col.stats.empty=Aucun enregistrement (ensemble vide)
 harvestserver.tab.col.stats.results={0} {0, choice, 0#Ensembles de données|1#Ensemble de données|2#Ensembles de données} ({1} {1, choice, 0#enregistrements|1#enregistrement|2#enregistrements} exporté(s), {2} marqué(s) comme supprimé(s))
 harvestserver.tab.header.action=Opérations
 harvestserver.tab.header.action.btn.export=Lancer l'exportation
-harvestserver.actions.runreexport.success=La tâche asynchrone de réexportation de l'ensemble OAI «\u00A0{0}\u00A0» a bien été lancée (veuillez recharger la page pour suivre la progression de l'exportation).
+harvestserver.actions.runreexport.success=La tâche asynchrone de réexportation de l''ensemble OAI «\u00A0{0}\u00A0» a bien été lancée (veuillez recharger la page pour suivre la progression de l''exportation).
 harvestserver.tab.header.action.btn.edit=Modifier
 harvestserver.tab.header.action.btn.delete=Supprimer
 harvestserver.tab.header.action.btn.delete.dialog.header=Supprimer l'ensemble à moissonner
-harvestserver.tab.header.action.btn.delete.dialog.tip=Voulez-vous vraiment supprimer l'ensemble OAI «\u00A0{0}\u00A0»? Vous ne pouvez pas annuler une suppression!
+harvestserver.tab.header.action.btn.delete.dialog.tip=Voulez-vous vraiment supprimer l''ensemble OAI «\u00A0{0}\u00A0»? Vous ne pouvez pas annuler une suppression!
 harvestserver.tab.header.action.delete.infomessage=L'ensemble à moissonner est supprimé. (Ceci peut prendre un certain temps)
 harvestserver.newSetDialog.title.new=Définir un ensemble à moissonner
 harvestserver.newSetDialog.help=Définir une collection d'ensembles de données locaux qui seront disponibles pour le moissonnage par les clients distants.
@@ -521,13 +521,13 @@ harvestserver.newSetDialog.setquery.required=La requête de recherche ne peut êtr
 harvestserver.newSetDialog.setquery.results=La requête de recherche a retourné {0} ensemble(s) de données!
 harvestserver.newSetDialog.setquery.empty=AVERTISSEMENT\u00A0: la requête de recherche n'a retourné aucun résultat!
 harvestserver.newSetDialog.btn.create=Créer l'ensemble
-harvestserver.newSetDialog.success=L'ensemble de données «\u00A0{0}\u00A0» a bien été créé.
+harvestserver.newSetDialog.success=L''ensemble de données «\u00A0{0}\u00A0» a bien été créé.
 harvestserver.viewEditDialog.title=Modifier l'ensemble moissonné.
 harvestserver.viewEditDialog.btn.save=Sauvegarder les modifications
 
 #dashboard-users.xhtml
 dashboard.card.users=Utilisateurs
-dashboard.card.users.header=Tableau de bord - Liste des utilisateurs
+dashboard.card.users.header=Tableau de bord — Liste des utilisateurs
 dashboard.card.users.super=Super-utilisateurs
 dashboard.card.users.manage=Gérer les utilisateurs
 dashboard.card.users.message=Lister et gérer les utilisateurs.
@@ -548,13 +548,13 @@ dashboard.list_users.tbl_header.lastLoginTime=Dernière connexion
 dashboard.list_users.tbl_header.lastApiUseTime=Dernière utilisation de l'API
 dashboard.list_users.tbl_header.roles.removeAll=Supprimer tout
 dashboard.list_users.tbl_header.roles.removeAll.header=Supprimer tous les rôles
-dashboard.list_users.tbl_header.roles.removeAll.confirmationText=Êtes-vous sûr de vouloir supprimer tous les rôles pour l'utilisateur {0}?
-dashboard.list_users.removeAll.message.success=Tous les rôles ont été supprimés pour l'utilisateur {0}.
-dashboard.list_users.removeAll.message.failure=Échec de la suppression des rôles pour l'utilisateur {0}.
+dashboard.list_users.tbl_header.roles.removeAll.confirmationText=Êtes-vous sûr de vouloir supprimer tous les rôles pour l''utilisateur {0}?
+dashboard.list_users.removeAll.message.success=Tous les rôles ont été supprimés pour l''utilisateur {0}.
+dashboard.list_users.removeAll.message.failure=Échec de la suppression des rôles pour l''utilisateur {0}.
 
 dashboard.list_users.toggleSuperuser=Modifier le statut de super-utilisateur
-dashboard.list_users.toggleSuperuser.confirmationText.add=Êtes-vous certain de vouloir activer le statut de super-utilisateur pour l'utilisateur {0}?
-dashboard.list_users.toggleSuperuser.confirmationText.remove=Êtes-vous certain de vouloir désactiver le statut de super-utilisateur pour l'utilisateur {0}?
+dashboard.list_users.toggleSuperuser.confirmationText.add=Êtes-vous certain de vouloir activer le statut de super-utilisateur pour l''utilisateur {0}?
+dashboard.list_users.toggleSuperuser.confirmationText.remove=Êtes-vous certain de vouloir désactiver le statut de super-utilisateur pour l''utilisateur {0}?
 dashboard.list_users.toggleSuperuser.confirm=Poursuivre
 dashboard.list_users.api.auth.invalid_apikey=La clé API n'est pas valide.
 dashboard.list_users.api.auth.not_superuser=Action Interdite. Vous devez être un super-utilisateur.
@@ -567,12 +567,12 @@ notification.email.grant.file.access.subject={0}\u00A0: L''accès à un fichier ré
 notification.email.rejected.file.access.subject={0}\u00A0: Votre demande d''accès à un fichier en accès réservé a été refusée.
 notification.email.update.maplayer={0}\u00A0: Une couche WorldMap a été ajoutée à l''ensemble de données.
 notification.email.maplayer.deletefailed.subject={0}: Impossible de supprimer la couche WorldMap.
-notification.email.maplayer.deletefailed.text=Impossible de supprimer la couche WorldMap associée au fichier à accès restreint {0}, ainsi que toutes les données connexes qui peuvent encore être publiquement disponibles sur le site de WorldMap. Essayez de nouveau, ou contactez le soutien WorldMap et/ou Dataverse. (Ensemble de données\u00A0: {1})
+notification.email.maplayer.deletefailed.text=Impossible de supprimer la couche WorldMap associée au fichier à accès restreint {0} ainsi que toutes les données connexes qui peuvent encore être publiquement disponibles sur le site de WorldMap. Essayez de nouveau, ou contactez le soutien WorldMap et/ou Dataverse. (Ensemble de données\u00A0: {1})
 notification.email.submit.dataset.subject={0}\u00A0: Votre ensemble de données a été soumis à la révision.
 notification.email.publish.dataset.subject={0}\u00A0: Votre ensemble de données a été publié.
 notification.email.returned.dataset.subject={0}\u00A0: Votre ensemble de données a été retourné.
 notification.email.create.account.subject={0}\u00A0: Votre compte a été créé.
-notification.email.assign.role.subject={0}\u00A0:  Un rôle vous a été attribué
+notification.email.assign.role.subject={0}\u00A0: Un rôle vous a été attribué
 notification.email.revoke.role.subject={0}\u00A0: Votre rôle a été révoqué
 notification.email.verifyEmail.subject={0}\u00A0: Valider votre adresse courriel
 notification.email.greeting=Bonjour, \n
@@ -583,9 +583,9 @@ notification.email.requestFileAccess=Accès au fichier demandé pour l''ensemble d
 notification.email.grantFileAccess=Accès accordé aux fichiers de l''ensemble de données\u00A0: {0} (voir {1}).
 notification.email.rejectFileAccess=Votre demande d''accès a été rejetée pour les fichiers demandés de l''ensemble de données\u00A0: {0} (voir {1}). Si vous avez des questions sur la raison pour laquelle votre demande a été rejetée, vous pouvez contacter le propriétaire de l''ensemble de données à l''aide du lien «\u00A0Personne-ressource\u00A0» dans le coin supérieur droit de la page de l''ensemble de données.
 # Bundle file editors, please note that "notification.email.createDataverse" is used in a unit test
-notification.email.createDataverse=Votre nouveau dataverse intitulé {0} (voir {1}) a été créé dans {2} (voir {3}). Pour en savoir plus sur ce que vous pouvez faire avec votre dataverse, consultez le Guide de l''utilisateur Dataverse à l''adresse suivante\u00A0: {4}/{5}/user/dataverse-management.html .
+notification.email.createDataverse=Votre nouveau dataverse intitulé {0} (voir {1}) a été créé dans {2} (voir {3}). Pour en apprendre davantage sur ce que vous pouvez faire avec votre dataverse, consultez le guide d''utilisation Dataverse à l''adresse suivante\u00A0: {4}/{5}/user/dataverse-management.html .
 # Bundle file editors, please note that "notification.email.createDataset" is used in a unit test
-notification.email.createDataset=Votre nouvel ensemble de données intitulé {0} (voir {1}) a été créé dans {2} (voir {3}). Pour en savoir plus sur ce que vous pouvez faire avec un ensemble de données, consultez le Guide Dataverse sur la gestion d''un ensemble de données à l''adresse suivante\u00A0: {4}/{5}/user/dataset-management.html .
+notification.email.createDataset=Votre nouvel ensemble de données intitulé {0} (voir {1}) a été créé dans {2} (voir {3}). Pour en apprendre davantage sur ce que vous pouvez faire avec un ensemble de données, consultez le guide d''utilisation Dataverse sur la gestion d''un ensemble de données à l''adresse suivante\u00A0: {4}/{5}/user/dataset-management.html .
 notification.email.wasSubmittedForReview={0} (voir {1}) a été soumis aux fins d''examen en vue de sa publication dans {2}  (voir {3}). N''oubliez pas de le publier ou de le renvoyer au collaborateur\!
 notification.email.wasReturnedByReviewer={0} (voir {1}) a été retourné par l''intendant des données de {2} (voir {3}).
 notification.email.wasPublished={0} (voir {1}) a été publié dans {2} (voir {3}).
@@ -608,14 +608,14 @@ pageTitle.passwdReset.pre=Réinitialisation du mot de passe du compte
 passwdReset.token=Jeton\u00A0:
 passwdReset.userLookedUp=Utilisateur recherché\u00A0:
 passwdReset.emailSubmitted=Courriel soumis\u00A0:
-passwdReset.details={0} Réinitialisation du mot de passe{1} - Pour débuter le processus de réinitialisation du mot de passe, veuillez indiquer votre adresse courriel. 
+passwdReset.details={0} Réinitialisation du mot de passe{1} — Pour débuter le processus de réinitialisation du mot de passe, veuillez indiquer votre adresse courriel. 
 passwdReset.submitRequest=Soumettre la demande de mot de passe
 passwdReset.successSubmit.tip=Si cette adresse courriel est associée à un compte, un courriel sera envoyé avec des instructions supplémentaires à {0}.
 passwdReset.debug=DÉBOGUER
 passwdReset.resetUrl=L'adresse URL réinitialisée est
-passwdReset.noEmail.tip=Aucun courriel n'a été envoyé étant donné qu'aucun utilisateur n'a été trouvé au moyen de l'adresse fournie {0}. Nous ne le mentionnons pas, car nous voulons éviter que des utilisateurs malveillants se servent du formulaire pour déterminer si un compte est associé à une adresse courriel. 
-passwdReset.illegalLink.tip=Le lien pour réinitialiser votre mot de passe n'est pas valide. Si vous devez réinitialiser votre mot de passe, {0}cliquez ici{1} pour demander à ce que votre mot de passe soit réinitialisé.
-passwdReset.newPasswd.details={0} Réinitialiser le mot de passe{1} \u2013 Nos exigences de composition de mot de passe ont changé. Veuillez choisir un mot de passe sécuritaire respectant les critères énumérés ci-après. 
+passwdReset.noEmail.tip=Aucun courriel n''a été envoyé étant donné qu''aucun utilisateur n''a été trouvé au moyen de l''adresse fournie {0}. Nous ne le mentionnons pas, car nous voulons éviter que des utilisateurs malveillants se servent du formulaire pour déterminer si un compte est associé à une adresse courriel. 
+passwdReset.illegalLink.tip=Le lien pour réinitialiser votre mot de passe n''est pas valide. Si vous devez réinitialiser votre mot de passe, {0}cliquez ici{1} pour demander à ce que votre mot de passe soit réinitialisé.
+passwdReset.newPasswd.details={0} Réinitialiser le mot de passe{1} — Nos exigences de composition de mot de passe ont changé. Veuillez choisir un mot de passe sécuritaire respectant les critères énumérés ci-après. 
 passwdReset.newPasswd=Nouveau mot de passe
 passwdReset.rePasswd=Confirmer le mot de passe
 passwdReset.resetBtn=Réinitialiser le mot de passe  
@@ -695,8 +695,8 @@ dataverse.savedsearch.no.choice=Vous avez un dataverse pour lequel vous pouvez a
 dataverse.saved.search.success=La recherche sauvegardée est maintenant liée à {0}.
 dataverse.saved.search.failure=La recherche sauvegardée n'a pas pu être liée.
 dataverse.linked.success={0} est maintenant lié à {1}.
-dataverse.linked.success.wait={0} a bien été lié à {1}. Veuillez attendre que le contenu s'affiche.
-dataverse.linked.internalerror={0} a bien été lié à {1} mais le contenu ne s'affichera pas avant qu'une erreur interne ne soit résolue.
+dataverse.linked.success.wait={0} a bien été lié à {1}. Veuillez attendre que le contenu s''affiche.
+dataverse.linked.internalerror={0} a bien été lié à {1} mais le contenu ne s''affichera pas avant qu'une erreur interne ne soit résolue.
 dataverse.page.pre=Précédent
 dataverse.page.next=Suivant
 dataverse.byCategory=Dataverses par catégorie
@@ -712,7 +712,7 @@ dataverse.delete=Supprimer le dataverse
 dataverse.delete.success=Votre dataverse a été supprimé.
 dataverse.delete.failure=Ce dataverse n'a pas pu être supprimé. 
 # Bundle file editors, please note that "dataverse.create.success" is used in a unit test because it's so fancy with two parameters
-dataverse.create.success=Vous avez bien réussi à créer votre dataverse! Pour en savoir davantage sur ce que vous pouvez faire avec votre dataverse, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Administration de Dataverse - Guide d'utilisation de Dataverse" target="_blank">guide d'utilisation</a>.
+dataverse.create.success=Vous avez bien réussi à créer votre dataverse! Pour en apprendre davantage sur ce que vous pouvez faire avec votre dataverse, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Administration de Dataverse — Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
 dataverse.create.failure=Ce dataverse n'a pas pu être créé. 
 dataverse.create.authenticatedUsersOnly=Seuls les utilisateurs authentifiés peuvent créer des dataverses.
 dataverse.update.success=Vous avez bien mis à jour votre dataverse!
@@ -759,18 +759,18 @@ dataverse.results.types.dataverses=Dataverses
 dataverse.results.types.datasets=Ensembles de données
 dataverse.results.types.files=Fichiers
 # Bundle file editors, please note that "dataverse.results.empty.zero" is used in a unit test
-dataverse.results.empty.zero=Aucun dataverse, ensemble de données ou fichier ne correspond à votre recherche. Veuillez effectuer une nouvelle recherche en utilisant d'autres termes ou des termes plus généraux. Vous pouvez également consulter le <a href="{0}/{1}/user/find-use-data.html" title="Trouver et utiliser des données - Guide d'utilisation de Dataverse" target="_blank">guide de recherche</a> pour des astuces.
+dataverse.results.empty.zero=Aucun dataverse, ensemble de données ou fichier ne correspond à votre recherche. Veuillez effectuer une nouvelle recherche en utilisant d''autres termes ou des termes plus généraux. Vous pouvez également consulter le <a href="{0}/{1}/user/find-use-data.html" title="Trouver et utiliser des données — Guide d''utilisation de Dataverse" target="_blank">guide de recherche</a> pour des astuces.
 # Bundle file editors, please note that "dataverse.results.empty.hidden" is used in a unit test
-dataverse.results.empty.hidden=Il n'y a pas de résultats répondants à vos critères de recherche. Vous pouvez consulter le <a href="{0}/{1}/user/find-use-data.html" title="Trouver et utiliser des données - Guide d'utilisation de Dataverse" target="_blank">guide de recherche</a> pour des conseils.
+dataverse.results.empty.hidden=Il n''y a pas de résultats répondants à vos critères de recherche. Vous pouvez consulter le <a href="{0}/{1}/user/find-use-data.html" title="Trouver et utiliser des données — Guide d''utilisation de Dataverse" target="_blank">guide de recherche</a> pour des conseils.
 dataverse.results.empty.browse.guest.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Veuillez <a href="/loginpage.xhtml{0}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour voir si vous pouvez y ajouter du contenu. 
 dataverse.results.empty.browse.guest.hidden=Ce dataverse ne contient aucun dataverse. Veuillez <a href="/loginpage.xhtml{0}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour voir si vous pouvez y ajouter du contenu. 
 dataverse.results.empty.browse.loggedin.noperms.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Vous pouvez utiliser le bouton «\u00A0Envoyer un courriel au contact du dataverse\u00A0» ci-dessus pour toute question sur ce dataverse ou pour effectuer une demande d'accès à ce dataverse.
 dataverse.results.empty.browse.loggedin.noperms.hidden=Il n'y a aucun dataverse dans ce dataverse.
 dataverse.results.empty.browse.loggedin.perms.zero=Ce dataverse ne contient actuellement aucun dataverse, ensemble de données ou fichier. Vous pouvez en ajouter à l'aide du bouton «\u00A0Ajouter des données\u00A0» qui se trouve sur cette page.
-account.results.empty.browse.loggedin.perms.zero=Il n'y a aucun dataverse, ensemble de données ou fichier associé à votre compte. Vous pouvez ajouter un dataverse ou un ensemble de données en cliquant sur le bouton «\u00A0Ajouter des données\u00A0» ci-dessus. Pour en savoir plus sur l'ajout de données, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Administration de Dataverse - Guide d'utilisation de Dataverse" target="_blank">guide d'utilisation</a>
+account.results.empty.browse.loggedin.perms.zero=Il n''y a aucun dataverse, ensemble de données ou fichier associé à votre compte. Vous pouvez ajouter un dataverse ou un ensemble de données en cliquant sur le bouton «\u00A0Ajouter des données\u00A0» ci-dessus. Pour en apprendre davantage sur l''ajout de données, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Administration de Dataverse — Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
 dataverse.results.empty.browse.loggedin.perms.hidden=Il n'y a aucun dataverse dans ce dataverse. Vous pouvez en ajouter à l'aide du bouton «\u00A0Ajouter des données\u00A0» qui se trouve sur cette page.
 dataverse.results.empty.link.technicalDetails=Plus de détails techniques
-dataverse.search.facet.error=Une erreur s'est produite avec vos paramètres de recherche. Veuillez <a href="/dataverse/{0}"> effacer votre recherche </a> et essayer de nouveau.
+dataverse.search.facet.error=Une erreur s''est produite avec vos paramètres de recherche. Veuillez <a href="/dataverse/{0}">supprimer votre recherche</a> et essayer de nouveau.
 dataverse.results.count.toofresults={0} à {1} de {2} {2, choice, 0#résultats|1#résultat|2#résultats}
 dataverse.results.paginator.current=(Actuel)
 dataverse.results.btn.sort=Tri
@@ -836,9 +836,9 @@ dataverse.widgets.notPublished.why.reason2=Permet aux autres de parcourir votre 
 dataverse.widgets.notPublished.how.header=Comment utiliser les widgets
 dataverse.widgets.notPublished.how.tip1=Pour pouvoir utiliser des widgets, votre dataverse et vos ensembles de données doivent être publiés.
 dataverse.widgets.notPublished.how.tip2=Suite à la publication, le code sera disponible sur cette page pour que vous puissiez le copier et l'ajouter à votre site web personnel ou de projet.
-dataverse.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l'ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title = "Ajouter des widgets à un site web OpenScholar - Guide d'utilisation de Dataverse" target ="_blank">ici</a>.
-dataverse.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets - Guide d'utilisation de Dataverse" target="_blank">thème et widgets</a> du guide d'utilisation.
-dataverse.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets - Guide d'utilisation de Dataverse" target="_blank">Thème et widgets</a> du guide d'utilisation.
+dataverse.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l''ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title = "Ajouter des widgets à un site web OpenScholar — Guide d''utilisation de Dataverse" target ="_blank">ici</a>.
+dataverse.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets — Guide d''utilisation de Dataverse" target="_blank">thème et widgets</a> du guide d''utilisation.
+dataverse.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets — Guide d''utilisation de Dataverse" target="_blank">Thème et widgets</a> du guide d''utilisation.
 dataverse.widgets.searchBox.txt=Boîte de recherche Dataverse
 dataverse.widgets.searchBox.tip=Permet aux visiteurs de votre site Web d'effectuer une recherche dans Dataverse.
 dataverse.widgets.dataverseListing.txt=Liste des dataverses
@@ -927,9 +927,9 @@ dataverse.permissions.Q1.answer2=Toute personne possédant un compte Dataverse pe
 dataverse.permissions.Q1.answer3=Toute personne possédant un compte Dataverse peut ajouter des ensembles de données.
 dataverse.permissions.Q1.answer4=Toute personne possédant un compte Dataverse peut ajouter des sous-dataverses et des ensembles de données.
 dataverse.permissions.Q2=Lorsqu'un utilisateur ajoute un nouvel ensemble de données à ce dataverse, quel rôle doit-il lui être attribué automatiquement sur cet ensemble de données?
-dataverse.permissions.Q2.answer.editor.description=- Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, soumettre les ensembles de données aux fins d'examen.
-dataverse.permissions.Q2.answer.manager.description=- Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, les restrictions relatives aux fichiers (accès aux fichiers + utilisation)
-dataverse.permissions.Q2.answer.curator.description=- Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, les restrictions relatives aux fichiers (accès aux fichiers + utilisation), modifier les permissions/assigner les rôles + publier
+dataverse.permissions.Q2.answer.editor.description=— Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, soumettre les ensembles de données aux fins d'examen.
+dataverse.permissions.Q2.answer.manager.description=— Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, les restrictions relatives aux fichiers (accès aux fichiers + utilisation)
+dataverse.permissions.Q2.answer.curator.description=— Modifier les métadonnées, téléverser les fichiers et modifier les fichiers, modifier les conditions, le registre des visiteurs, les restrictions relatives aux fichiers (accès aux fichiers + utilisation), modifier les permissions/assigner les rôles + publier
 permission.anyoneWithAccount=Toute personne possédant un compte Dataverse
 
 # roles-assign.xhtml
@@ -940,7 +940,7 @@ dataverse.permissions.usersOrGroups.assignDialog.userOrGroup.enterName=Indiquer 
 dataverse.permissions.usersOrGroups.assignDialog.userOrGroup.invalidMsg=Aucun résultat
 dataverse.permissions.usersOrGroups.assignDialog.userOrGroup.requiredMsg=Veuillez sélectionner au moins un utilisateur ou un groupe.
 dataverse.permissions.usersOrGroups.assignDialog.role.description=Voici les permissions associées au rôle sélectionné.
-dataverse.permissions.usersOrGroups.assignDialog.role.warning=L'attribution du rôle {0} signifie que le ou les utilisateurs auront également le rôle {0} qui s'applique à tous les {1} dans ce {2}.
+dataverse.permissions.usersOrGroups.assignDialog.role.warning=L''attribution du rôle {0} signifie que le ou les utilisateurs auront également le rôle {0} qui s''applique à tous les {1} dans ce {2}.
 dataverse.permissions.usersOrGroups.assignDialog.role.requiredMsg=Veuillez sélectionner un rôle à attribuer.
 
 # roles-edit.xhtml
@@ -982,7 +982,7 @@ dataset.manageTemplates.noTemplates.why.reason2=Les modèles peuvent être utilisé
 dataset.manageTemplates.noTemplates.how.header=Comment utiliser les modèles
 dataset.manageTemplates.noTemplates.how.tip1=Les modèles sont créés au niveau du dataverse, peuvent être supprimés (si on ne veut pas qu'ils paraissent dans les futurs ensembles de données), sont activés par défaut (non requis) et peuvent être copiés de façon à ce que vous n'ayez pas à recommencer du début lorsque vous créez un nouveau modèle contenant des métadonnées similaires à un autre modèle. Lorsqu'un modèle est supprimé, il n'y a aucune incidence sur les ensembles de données qui ont déjà utilisé le modèle.
 dataset.manageTemplates.noTemplates.how.tip2=Veuillez noter que la possibilité de choisir les champs de métadonnées qui seront cachés, obligatoires ou facultatifs est disponible sur la page <a href="/dataverse/{0}?editMode=INFO" title="Renseignements généraux sur Dataverse">Renseignements généraux</a> de ce dataverse.
-dataset.manageTemplates.noTemplates.getStarted=Pour commencer, cliquez sur le bouton «\u00A0Créer un modèle d'ensemble de données\u00A0» ci-dessus. Pour en savoir plus au sujet des modèles, consultez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-templates" title="Modèles d'ensemble de données - Guide d'utilisation de Dataverse" target="_blank">modèles d'ensemble de données</a>du guide d'utilisation.
+dataset.manageTemplates.noTemplates.getStarted=Pour commencer, cliquez sur le bouton «\u00A0Créer un modèle d''ensemble de données\u00A0» ci-dessus. Pour en apprendre davantage au sujet des modèles, consultez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-templates" title="Modèles d''ensemble de données — Guide d''utilisation de Dataverse" target="_blank">modèles d''ensemble de données</a>du guide d''utilisation.
 dataset.manageTemplates.tab.header.templte=Nom du modèle
 dataset.manageTemplates.tab.header.date=Date de création
 dataset.manageTemplates.tab.header.usage=Usage
@@ -1060,7 +1060,7 @@ dataset.manageGuestbooks.noGuestbooks.why.reason2=Vous pouvez télécharger les do
 dataset.manageGuestbooks.noGuestbooks.how.header=Comment utiliser les registres de visiteurs
 dataset.manageGuestbooks.noGuestbooks.how.tip1=Un registre des visiteurs peut être utilisé pour plusieurs ensembles de données, mais un seul registre des visiteurs peut être utilisé pour un ensemble de données.
 dataset.manageGuestbooks.noGuestbooks.how.tip2=Les questions personnalisées peuvent comprendre des réponses en texte libre ou des questions à choice de réponses.
-dataset.manageGuestbooks.noGuestbooks.getStarted=Pour commencer, cliquer ci-dessus sur le bouton «\u00A0Créer un registre des visiteurs pour l'ensemble de données\u00A0». Pour en savoir plus sur les registres de visiteurs, visitez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-guestbooks" title="Registre des visiteurs de l'ensemble de données - Guide d'utilisation de Dataverse" target="_blank">registre des visiteurs</a> du guide d'utilisation.
+dataset.manageGuestbooks.noGuestbooks.getStarted=Pour commencer, cliquez ci-dessus sur le bouton «\u00A0Créer un registre des visiteurs pour l''ensemble de données\u00A0». Pour en apprendre davantage sur les registres de visiteurs, visitez la section <a href="{0}/{1}/user/dataverse-management.html\#dataset-guestbooks" title="Registre des visiteurs de l''ensemble de données — Guide d''utilisation de Dataverse" target="_blank">registre des visiteurs</a> du guide d''utilisation.
 dataset.manageGuestbooks.tab.header.name=Nom du registre des visiteurs
 dataset.manageGuestbooks.tab.header.date=Date de création
 dataset.manageGuestbooks.tab.header.usage=Usage
@@ -1101,7 +1101,7 @@ dataset.guestbooksResponses.tip.title=Entrées du registre de visiteur
 dataset.guestbooksResponses.count.responses={0} {0, choice, 0#Entrées|1#Entrée|2#Entrées}
 dataset.guestbooksResponses.count.toofresults={0} à {1} de {2} {2, choice, 0#Entrées|1#Entrée|2#Entrées}
 dataset.guestbooksResponses.tip.downloadascsv=Cliquer sur «\u00A0Télécharger les entrées\u00A0» pour télécharger dans un fichier CSV les entrées recueillies dans le registre de visiteurs de ce dataverse. Pour naviguer et analyser les données ainsi collectées, nous vous recommandons d'importer ce fichier CSV dans Excel, Google Sheets ou un logiciel similaire.
-dataset.guestbooksResponses.tooManyResponses.message=Note\u00A0: ce registre de visiteurs contient trop d'entrées pour qu'elles puissent être affichées entièrement sur cette page. Seules les {0} entrées les plus récentes sont affichées ci-dessous. Cliquez sur «\u00A0Télécharger les entrées\u00A0» pour télécharger toutes les entrées recueillies ({1} au total) en tant que fichier CSV.
+dataset.guestbooksResponses.tooManyResponses.message=Note\u00A0: ce registre de visiteurs contient trop d''entrées pour qu''elles puissent être affichées entièrement sur cette page. Seules les {0} entrées les plus récentes sont affichées ci-dessous. Cliquez sur «\u00A0Télécharger les entrées\u00A0» pour télécharger toutes les entrées recueillies ({1} au total) sous forme de fichier CSV.
 
 # guestbook-responses.xhtml
 dataset.guestbookResponses.pageTitle=Entrées du registre de visiteur
@@ -1161,7 +1161,7 @@ dataset.disabledSubmittedBtn=Soumis à la révision
 dataset.submitMessage=Vous ne serez pas en mesure d'apporter des modifications à cet ensemble de données pendant sa révision.
 dataset.submit.success=Votre ensemble de données a été soumis pour révision.
 dataset.inreview.infoMessage=\u2013 Cet ensemble de données est actuellement en cours de révision avant publication.
-dataset.submit.failure=Échec de la soumission de l'ensemble de données - {0}
+dataset.submit.failure=Échec de la soumission de l''ensemble de données — {0}
 dataset.submit.failure.null=Impossible de soumettre à la révision. L'ensemble de données est nul.
 dataset.submit.failure.isReleased=La dernière version de l'ensemble de données est déjà publiée. Seules les versions provisoires peuvent être soumises pour révision.
 dataset.submit.failure.inReview=Vous ne pouvez pas soumettre cet ensemble de données à la révision, car il est déjà en cours de vérification.
@@ -1170,7 +1170,7 @@ dataset.rejectWatermark=Veuillez entrer une raison pour laquelle cet ensemble de
 dataset.reject.enterReason=La raison du retour à l'auteur est requise
 dataset.reject.enterReason.header=Entrée obligatoire
 dataset.reject.success=Cet ensemble de données à été renvoyé au collaborateur.
-dataset.reject.failure=Échec de la soumission du renvoi de l'ensemble de données - {0}
+dataset.reject.failure=Échec de la soumission du renvoi de l''ensemble de données — {0}
 dataset.reject.datasetNull=Impossible de renvoyer l'ensemble de données à l'auteur (s) car il est null.
 dataset.reject.datasetNotInReview=Cet ensemble de données ne peut pas être renvoyé à (aux) l'auteur (s), car la dernière version n'est pas en révision. L' (les) auteur(s) doit (doivent) d'abord cliquer sur «\u00A0Soumettre pour révision\u00A0».
 dataset.publish.tip=Êtes-vous sûr(e) de vouloir publier cet ensemble de données? Une fois publié, il doit demeurer publié.
@@ -1180,10 +1180,10 @@ dataset.republish.tip=Êtes-vous sûr(e) de vouloir publier à nouveau cet ensemble
 dataset.selectVersionNumber=Indiquer s'il s'agit d'une mise à jour mineure ou majeure de la version.
 dataset.majorRelease=Version majeure
 dataset.minorRelease=Version mineure
-dataset.majorRelease.tip=En raison de la nature des modifications apportées à la version provisoire actuelle, il s'agira d'une version majeure({0}).
+dataset.majorRelease.tip=En raison de la nature des modifications apportées à la version provisoire actuelle, il s''agira d''une version majeure ({0}).
 dataset.mayNotBePublished=Impossible de publier l'ensemble de données
-dataset.mayNotPublish.administrator=Cet ensemble de données ne peut être publié tant que {0} n'est pas publié par son administrateur.
-dataset.mayNotPublish.both=Cet ensemble de données ne peut être publié tant que {0} n'est pas publié. Voulez-vous publier les deux immédiatement?
+dataset.mayNotPublish.administrator=Cet ensemble de données ne peut être publié tant que {0} n''est pas publié par son administrateur.
+dataset.mayNotPublish.both=Cet ensemble de données ne peut être publié tant que {0} n''est pas publié. Voulez-vous publier les deux immédiatement?
 dataset.mayNotPublish.twoGenerations=Cet ensemble de données ne peut être publié tant que {0} et {1} ne sont pas publiés.
 dataset.mayNotBePublished.both.button=Oui, publier les deux.
 dataset.viewVersion.unpublished=Voir la version non publiée
@@ -1197,7 +1197,7 @@ dataset.share.datasetShare.tip=Partager cet ensemble de données sur vos médias s
 dataset.share.datasetShare.shareText=Consulter cet ensemble de données
 dataset.locked.message=Ensemble de données verrouillé
 dataset.locked.inReview.message=Soumis pour révision
-dataset.publish.error=L'ensemble de données ne peut être publié, car le service de <a href=\{1} target=\"_blank\"/> {0} </a> est actuellement inaccessible. Veuillez essayer à nouveau. Le problème persiste-il? 
+dataset.publish.error=L''ensemble de données ne peut être publié, car le service de <a href=\{1} target=\"_blank\"/>{0}</a> est actuellement inaccessible. Veuillez essayer à nouveau. Le problème persiste-il? 
 dataset.publish.error.doi=L'ensemble de données ne peut être retiré, car la mise à jour DOI a échoué. 
 dataset.compute.computeBatchSingle=Calcul de l'ensemble de données
 dataset.compute.computeBatchList=Lister lot
@@ -1210,7 +1210,7 @@ dataset.compute.computeBatch.failure=Échec de la mise à jour de la liste des ens
 dataset.compute.computeBtn=Calculer
 dataset.compute.computeBatchListHeader=Calcul du lot
 dataset.compute.computeBatchRestricted=Cet ensemble de données contient des fichiers à accès restreint sur lesquels vous ne pouvez y effectuer un calcul puisque vous ne bénéficiez pas des autorisations nécessaires.
-dataset.delete.error=L'ensemble de données ne peut être retiré, car la mise à jour {0} a échoué.
+dataset.delete.error=L''ensemble de données ne peut être retiré, car la mise à jour {0} a échoué.
 dataset.publish.worldMap.deleteConfirm=Veuillez noter que vos données et votre carte sur WorldMap seront supprimées en raison de modifications des restrictions d'accès aux fichiers dans cette version de l'ensemble de données que vous publiez. Voulez-vous continuer?
 dataset.publish.workflow.inprogress=Publier le flux de travail en cours
 dataset.pidRegister.workflow.inprogress=Enregistrement/mise à jour du flux de travail des identifiants persistants en cours
@@ -1221,7 +1221,7 @@ dataset.versionUI.deaccessioned=Retirée
 dataset.cite.title.released=La VERSION PROVISOIRE sera remplacée dans la référence bibliographique par la V1 une fois l'ensemble de données publié.
 dataset.cite.title.draft=La VERSION PROVISOIRE sera remplacée dans la référence bibliographique par la version sélectionnée une fois l'ensemble de données publié.
 dataset.cite.title.deassessioned=La mention VERSION RETIRÉE a été ajoutée à la référence bibliographique pour cette version étant donné qu'elle n'est plus disponible.
-dataset.cite.standards.tip=Pour en apprendre davantage sur le sujet, consultez le document <a href="https://dataverse.org/best-practices/data-citation" title="Data Citation  - Dataverse Best Practices" target="_blank">Data Citation Standards [en]</a>.
+dataset.cite.standards.tip=Pour en apprendre davantage sur le sujet, consultez le document <a href="https://dataverse.org/best-practices/data-citation" title="Data Citation — Dataverse Best Practices" target="_blank">Data Citation Standards [en]</a>.
 dataset.cite.downloadBtn=Citer l'ensemble de données
 dataset.cite.downloadBtn.xml=EndNote XML
 dataset.cite.downloadBtn.ris=RIS
@@ -1234,7 +1234,7 @@ dataset.keywordDisplay.title=Mot-clé
 dataset.subjectDisplay.title=Sujet
 dataset.contact.tip=Utiliser le bouton de courriel ci-dessus pour communiquer avec cette personne. 
 dataset.asterisk.tip=Les astérisques indiquent les champs obligatoires.
-dataset.message.uploadFiles=Téléverser les fichiers de l'ensemble de données - Vous pouvez glisser-déplacer les fichiers à partir de votre ordinateur vers le widget de téléversement. 
+dataset.message.uploadFiles=Téléverser les fichiers de l'ensemble de données — Vous pouvez glisser-déplacer les fichiers à partir de votre ordinateur vers le widget de téléversement. 
 dataset.message.editMetadata=Modifier les métadonnées de l'ensemble de données\u00A0: ajouter plus de métadonnées afin de faciliter le repérage de cet ensemble.
 dataset.message.editTerms=Modifier les conditions de l'ensemble de données\u00A0: mettre à jour les conditions d'utilisation de cet ensemble de données.
 dataset.message.locked.editNotAllowedInReview=L'ensemble de données ne peut pas être modifié en raison du verrouillage de l'ensemble de données en révision.
@@ -1242,14 +1242,14 @@ dataset.message.locked.downloadNotAllowedInReview=Les fichiers de l'ensemble de 
 dataset.message.locked.downloadNotAllowed=Les fichiers de l'ensemble de données ne peuvent pas être téléchargés en raison du verrouillage de l'ensemble de données.
 dataset.message.locked.editNotAllowed=L'ensemble de données ne peut pas être édité en raison de son verrouillage.
 dataset.message.createSuccess=Cet ensemble de données a été créé
-dataset.message.createSuccess.failedToSaveFiles=Succès partiel\u00A0: l'ensemble de données a été créé. Mais le(s) fichier(s) n'a(ont) pas pu être sauvegardé(s). Veuillez réessayer de téléverser le(s) fichier(s) de nouveau.
-dataset.message.createSuccess.partialSuccessSavingFiles=Succès partiel\u00A0: l'ensemble de données a été créé. Mais seul(s) {0} sur {1} fichier(s) a(ont) été enregistré(s). Veuillez réessayer de téléverser le(s) fichier(s) manquant(s) de nouveau.
+dataset.message.createSuccess.failedToSaveFiles=Succès partiel\u00A0: l'ensemble de données a été créé mais le(s) fichier(s) n'a(ont) pas pu être sauvegardé(s). Veuillez réessayer de téléverser le(s) fichier(s) de nouveau.
+dataset.message.createSuccess.partialSuccessSavingFiles=Succès partiel\u00A0: l''ensemble de données a été créé mais seul(s) {0} sur {1} fichier(s) a(ont) été enregistré(s). Veuillez réessayer de téléverser le(s) fichier(s) manquant(s) de nouveau.
 dataset.message.linkSuccess=Cet ensemble de données est maintenant lié à {1}.
 dataset.message.metadataSuccess=Les métadonnées de cet ensemble de données ont été mises à jour.
 dataset.message.termsSuccess=Les conditions de cet ensemble de données ont été mises à jour.
 dataset.message.filesSuccess=Les fichiers de cet ensemble de données ont été mis à jour.
 dataset.message.addFiles.Failure=Impossible d'ajouter des fichiers à l'ensemble de données. Veuillez réessayer de télécharger le(s) fichier(s) de nouveau. 
-dataset.message.addFiles.partialSuccess=Succès partiel\u00A0: seul(s) {0} sur {1} fichier(s) a(ont) été enregistré(s). Veuillez réessayer de téléverser le(s) fichier(s) manquant(s) de nouveau.
+dataset.message.addFiles.partialSuccess=Succès partiel\u00A0: seul(s) {0} sur {1} fichier(s) a(ont) été enregistré(s). Veuillez essayer de téléverser le(s) fichier(s) manquant(s) de nouveau.
 dataset.message.publishSuccess=Cet ensemble de données a été publié. 
 dataset.message.only.authenticatedUsers=Seuls les utilisateurs authentifiés peuvent publier des ensembles de données. 
 dataset.message.deleteSuccess=Cet ensemble de données a été supprimé. 
@@ -1258,7 +1258,7 @@ dataset.message.bulkFileDeleteSuccess=Les fichiers sélectionnés ont été supprimé
 datasetVersion.message.deleteSuccess=La version provisoire de cet ensemble de données a été supprimée.
 datasetVersion.message.deaccessionSuccess=La ou les versions sélectionnées ont été retirées.
 dataset.message.deaccessionSuccess=Cet ensemble de données a été retiré.
-dataset.message.validationError=Erreur de validation - Les champs obligatoires ont été omis ou il y a eu une erreur de validation. Veuillez défiler le menu vers le bas pour voir les détails. 
+dataset.message.validationError=Erreur de validation — Les champs obligatoires ont été omis ou il y a eu une erreur de validation. Veuillez défiler le menu vers le bas pour voir les détails. 
 dataset.message.publishFailure=L'ensemble de données n'a pas pu être publié.
 dataset.message.metadataFailure=Les métadonnées n'ont pas pu être mises à jour.
 dataset.message.filesFailure=Les fichiers n'ont pas pu être téléchargés.
@@ -1268,7 +1268,7 @@ dataset.message.deleteFailure=La version provisoire de cet ensemble de données n
 dataset.message.deaccessionFailure=Cet ensemble de données n'a pas pu être retiré. 
 dataset.message.createFailure=L'ensemble de données n'a pas pu être créé.
 dataset.message.termsFailure=Les conditions de cet ensemble de données n'ont pas pu être mises à jour.
-dataset.message.publicInstall=Accès aux fichiers - Les fichiers sont stockés sur un serveur de stockage accessible publiquement.
+dataset.message.publicInstall=Accès aux fichiers — Les fichiers sont stockés sur un serveur de stockage accessible publiquement.
 dataset.metadata.publicationDate=Date de publication
 dataset.metadata.publicationDate.tip=La date de publication d'un ensemble de données.
 dataset.metadata.persistentId=Identifiant pérenne de l'ensemble de données
@@ -1292,10 +1292,10 @@ dataset.noValidSelectedFilesForDownload=Le ou les fichiers réservés sélectionnés
 dataset.mixedSelectedFilesForDownload=Le ou les fichiers réservés sélectionnés ne peuvent être téléchargés, car les accès ne vous ont pas été accordés.
 dataset.downloadUnrestricted=Cliquez sur Continuer pour télécharger les fichiers pour lesquels vous avez un accès.
 dataset.requestAccessToRestrictedFiles=Vous pouvez demander l'accès à un ou des fichiers réservés en cliquant sur le bouton «\u00A0Demander l'accès\u00A0».
-dataset.privateurl.infoMessageAuthor=URL privé de l'ensemble de données non publié - Partager en privé cet ensemble de données avant sa publication\u00A0: {0}
-dataset.privateurl.infoMessageReviewer=URL privé de l'ensemble de données non publié -  Cet ensemble de données non publié est partagé en privé. Vous ne pourrez pas y accéder lorsque connecté à votre compte Dataverse.
+dataset.privateurl.infoMessageAuthor=URL privé de l''ensemble de données non publié — Partager en privé cet ensemble de données avant sa publication\u00A0: {0}
+dataset.privateurl.infoMessageReviewer=URL privé de l'ensemble de données non publié — Cet ensemble de données non publié est partagé en privé. Vous ne pourrez pas y accéder lorsque connecté à votre compte Dataverse.
 dataset.privateurl.header=URL privée de l'ensemble de données non publié
-dataset.privateurl.tip=Utilisez une adresse URL privée pour permettre à ceux qui n'ont pas de compte Dataverse d'accéder à votre ensemble de données non publié. Pour plus d'informations sur la fonctionnalité d'URL privé, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#private-url-for-reviewing-an-unpublished-dataset" title="URL privé pour vérifier un esmeble de données non publié - Guide d'utilisation de Dataverse" target="_blank">guide d'utilisation</a>.
+dataset.privateurl.tip=Utiliser une adresse URL privée pour permettre à ceux qui n''ont pas de compte Dataverse d''accéder à votre ensemble de données non publié. Pour plus d''informations sur la fonctionnalité d''URL privé, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#private-url-for-reviewing-an-unpublished-dataset" title="URL privé pour vérifier un ensemble de données non publié — Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
 dataset.privateurl.absent=L'adresse URL privée n'a pas été créée.
 dataset.privateurl.createPrivateUrl=Créer une adresse URL privée
 dataset.privateurl.disablePrivateUrl=Désactiver l'URL privé
@@ -1310,7 +1310,7 @@ file.count={0} {0, choice, 0#Fichiers|1#Fichiers|2#Fichiers}
 file.count.selected={0} {0, choice, 0#Fichiers sélectionnés|1#Fichier sélectionné|2#Fichiers sélectionnés}
 file.selectToAddBtn=Sélectionner les fichiers à ajouter
 file.selectToAdd.tipLimit=La limite de téléversement est de {0} par fichier.
-file.selectToAdd.tipMoreInformation=Pour plus d'informations sur les formats de fichiers pris en charge, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#file-handling-uploading" title="Manipulation et téléversement de fichiers - Guide d'utilisation de Dataverse" target="_blank">guide d'utilisation</a>.
+file.selectToAdd.tipMoreInformation=Pour plus d''informations sur les formats de fichiers pris en charge, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#file-handling-uploading" title="Manipulation et téléversement de fichiers — Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
 file.selectToAdd.dragdropMsg=Glisser et déposer les fichiers ici.
 file.createUploadDisabled=Une fois que vous avez sauvegardé votre ensemble de données, vous pouvez téléverser vos données en utilisant le bouton «\u00A0Téléverser des fichiers\u00A0» sur la page de l'ensemble de données. Pour plus d'informations sur les formats de fichiers pris en charge, reportez-vous au guide d'utilisation.
 file.fromDropbox=Téléverser à partir de Dropbox
@@ -1332,12 +1332,12 @@ file.replaced.warning.previous.warningMessage=Vous ne pouvez pas éditer un fichi
 file.alreadyDeleted.previous.warningMessage=Ce fichier a déjà été supprimé dans la version actuelle. Il peut ne pas être modifié.
 file.delete=Supprimer
 file.metadata=Métadonnées
-file.deleted.success=En cliquant sur «\u00A0Enregistrer les modifications\u00A0», les fichiers «\u00A0{0}\u00A0» seront supprimés de façon permanente de cette version de l'ensemble de données.
+file.deleted.success=En cliquant sur «\u00A0Enregistrer les modifications\u00A0», les fichiers «\u00A0{0}\u00A0» seront supprimés de façon permanente de cette version de l''ensemble de données.
 file.deleted.replacement.success=Le fichier de remplacement a été supprimé.
 file.editAccess=Modifier les accès
 file.restrict=Restreindre
 file.unrestrict=Sans restriction
-file.restricted.success=L'accès aux fichiers «\u00A0{0}\u00A0» sera restreint du moment où vous cliquerez sur le bouton «\u00A0Enregistrer les modifications\u00A0» au bas de la page.
+file.restricted.success=L''accès aux fichiers «\u00A0{0}\u00A0» sera restreint du moment où vous cliquerez sur le bouton «\u00A0Enregistrer les modifications\u00A0» au bas de la page.
 file.download.header=Télécharger
 file.download.subset.header=Télécharger le sous-ensemble de données
 file.preview=Aperçu\u00A0:
@@ -1350,16 +1350,16 @@ file.selectedThumbnail=Vignette
 file.selectedThumbnail.tip=La vignette associée au fichier est utilisée comme vignette par défaut pour l'ensemble de données. Cliquez sur le bouton «\u00A0Options avancées\u00A0» d'un autre fichier pour sélectionner ce fichier.
 file.cloudStorageAccess=Accès au stockage infonuagique
 file.cloudStorageAccess.tip=Le nom du conteneur pour cet ensemble de données doit accéder aux fichiers dans le stockage infonuagique.
-file.cloudStorageAccess.help=Pour accéder directement à ces données dans l'environnement infonuagique {2}, utilisez le nom du conteneur dans la case d'accès au stockage infonuagique ci-dessous. Pour en savoir plus sur l'environnement infonuagique, consultez la section <a href="{0}/{1}/user/dataset-management.html#cloud-storage" title="Accès au stockage en infonuagique - Guide d'utilisation de Dataverse" target="_blank">accès au stockage infonuagique</a> du guide d'utilisation.
+file.cloudStorageAccess.help=Pour accéder directement à ces données dans l''environnement infonuagique {2}, utilisez le nom du conteneur dans la case d''accès au stockage infonuagique ci-dessous. Pour en apprendre davantage sur l''environnement infonuagique, consultez la section <a href="{0}/{1}/user/dataset-management.html#cloud-storage" title="Accès au stockage en infonuagique — Guide d''utilisation de Dataverse" target="_blank">accès au stockage infonuagique</a> du guide d''utilisation.
 file.copy=Copier
 file.compute=Calculer
-file.rsyncUpload.info=Veuillez suivre ces étapes pour téléverser vos données. Pour en apprendre davantage sur le processus de téléversement et sur comment préparer vos données, veuillez vous reporter à la section <a href = "{0}/{1}/user/dataset-management.html#file-handling-and-uploading" title = "Manipulation et téléchargement de fichiers - Guide d'utilisation de Dataverse" target ="_ blank">Manipulation et téléchargement de fichiers</a> du guide d'utilisation.
+file.rsyncUpload.info=Veuillez suivre ces étapes pour téléverser vos données. Pour en apprendre davantage sur le processus de téléversement et sur comment préparer vos données, veuillez vous reporter à la section <a href = "{0}/{1}/user/dataset-management.html#file-handling-and-uploading" title = "Manipulation et téléchargement de fichiers — Guide d''utilisation de Dataverse" target ="_ blank">Manipulation et téléchargement de fichiers</a> du guide d''utilisation.
 file.rsyncUpload.noScriptAvailable=Le script Rsync n'est pas disponible!
 file.rsyncUpload.filesExist=Vous ne pouvez pas téléverser des fichiers supplémentaires dans cet ensemble de données.
 file.rsyncUpload.step1=Assurez-vous que vos données sont stockées dans un seul répertoire. Tous les fichiers de ce répertoire et de ses sous-répertoires seront téléversés dans votre ensemble de données.
 file.rsyncUpload.step2=Télécharger ce script de téléversement de fichiers\u00A0:
 file.rsyncUpload.step2.downloadScriptButton=Télécharger le script
-file.rsyncUpload.step3=Ouvrir une fenêtre de terminal dans le même répertoire que celui où vous avez enregistré le script et exécuter cette commande\u00A0: <code> bash ./{0} </code>
+file.rsyncUpload.step3=Ouvrir une fenêtre de terminal dans le même répertoire que celui où vous avez enregistré le script et exécuter cette commande\u00A0: <code>bash ./{0}</code>
 file.rsyncUpload.step4=Suivre les instructions du script. Il vous sera demandé un chemin complet (commençant par  «\u00A0/\u00A0») vers le répertoire contenant vos données. Note\u00A0: ce script expirera après 7 jours.
 file.rsyncUpload.inProgressMessage.summary=Téléchargement de fichier DCM
 file.rsyncUpload.inProgressMessage.details=Cet ensemble de données est verrouillé jusqu'à ce que les fichiers de données aient été transférés et vérifiés.
@@ -1415,7 +1415,7 @@ file.downloadBtn.format.datasubset=Sous-ensemble de données
 file.more.information.link=Mettre un lien vers plus d'information sur le fichier\u00A0: 
 file.requestAccess=Demander l'accès
 file.requestAccess.dialog.msg=Vous devez <a href="/loginpage.xhtml{0}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour demander un accès à ce fichier.
-file.requestAccess.dialog.msg.signup=Vous devez <a href="{0}" target="{1}" title="Inscrivez-vous pour ouvrir un compte Dataverse">ouvrir un compte</a> ou <a href="/loginpage.xhtml{0}" target="{1}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour demander un accès à ce fichier.
+file.requestAccess.dialog.msg.signup=Vous devez <a href="{0}" target="{1}" title="Inscrivez-vous pour ouvrir un compte Dataverse">ouvrir un compte</a> ou <a href="/loginpage.xhtml{0}" target="{1}" title="Connexion à votre compte Dataverse">vous authentifier</a> pour pouvoir demander un accès à ce fichier.
 file.accessRequested=Accès demandé
 file.restrictions=Restrictions d'accès aux fichiers
 file.restrictions.description=Limiter l'accès aux fichiers publiés en les indiquant comme étant restreints. Fournir aux utilisateurs les Conditions d'accès et leur permettre de demander l'accès.
@@ -1428,16 +1428,16 @@ file.dataFilesTab.terms.editTermsBtn=Modifier les conditions
 file.dataFilesTab.terms.list.termsOfUse.header=Conditions d'utilisation
 file.dataFilesTab.terms.list.termsOfUse.waiver=Licence accordée
 file.dataFilesTab.terms.list.termsOfUse.waiver.title=La licence permet d'informer les utilisateurs de ce qui leur est permis de faire avec ces données téléchargées. 
-file.dataFilesTab.terms.list.termsOfUse.waiver.txt=licence CC0 - «\u00A0Transfert dans le domaine public\u00A0»
-file.dataFilesTab.terms.list.termsOfUse.waiver.description=Les ensembles de données se verront attribuer par défaut une <a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Transfert dans le domaine public - Creative Commons" target="_blank">licence CC0 - Transfert dans le domaine public</a>. CC0 facilite la réutilisation et l'extensibilité des données de recherche. Nos <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Normes de la communauté Dataverse - Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Si vous ne pouvez accorder une licence CC0, vous pouvez établir des conditions d'utilisation personnalisées pour vos ensembles de données. 
+file.dataFilesTab.terms.list.termsOfUse.waiver.txt=licence CC0 — «\u00A0Transfert dans le domaine public\u00A0»
+file.dataFilesTab.terms.list.termsOfUse.waiver.description=Les ensembles de données se verront attribuer par défaut une <a href="https://creativecommons.org/publicdomain/zero/1.0/" title="Transfert dans le domaine public — Creative Commons" target="_blank">licence CC0 — Transfert dans le domaine public</a>. CC0 facilite la réutilisation et l'extensibilité des données de recherche. Nos <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Normes de la communauté Dataverse — Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Si vous ne pouvez accorder une licence CC0, vous pouvez établir des conditions d'utilisation personnalisées pour vos ensembles de données. 
 file.dataFilesTab.terms.list.termsOfUse.no.waiver.txt=Aucune licence n'a été sélectionnée pour cet ensemble de données. 
-file.dataFilesTab.terms.list.termsOfUse.waiver.txt.description=Les <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Normes de la communauté Dataverse - Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Veuillez utiliser la référence bibliographique ci-dessus générée par Dataverse.
-file.dataFilesTab.terms.list.termsOfUse.waiver.select.CCO=Oui, appliquer la licence CC0 - «\u00A0Transfert dans le domaine public\u00A0».
-file.dataFilesTab.terms.list.termsOfUse.waiver.select.notCCO=Non, ne pas appliquer la licence CC0 - «\u00A0Transfert dans le domaine public\u00A0».
+file.dataFilesTab.terms.list.termsOfUse.waiver.txt.description=Les <a href="https://dataverse.org/best-practices/dataverse-community-norms" title="Normes de la communauté Dataverse — Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Veuillez utiliser la référence bibliographique ci-dessus générée par Dataverse.
+file.dataFilesTab.terms.list.termsOfUse.waiver.select.CCO=Oui, appliquer la licence CC0 — «\u00A0Transfert dans le domaine public\u00A0».
+file.dataFilesTab.terms.list.termsOfUse.waiver.select.notCCO=Non, ne pas appliquer la licence CC0 — «\u00A0Transfert dans le domaine public\u00A0».
 file.dataFilesTab.terms.list.termsOfUse.waiver.select.tip=Voici ce que les utilisateurs finaux verront affiché pour cet ensemble de données.
 file.dataFilesTab.terms.list.termsOfUse.termsOfUse=Conditions d'utilisation
 file.dataFilesTab.terms.list.termsOfUse.termsOfUse.title=Indique la façon dont ces données peuvent être utilisées une fois téléchargées.
-file.dataFilesTab.terms.list.termsOfUse.termsOfUse.description=Si vous n'êtes pas en mesure d'utiliser la licence CC0 pour les ensembles de données, vous pouvez établir des conditions d'utilisation personnalisées. Voici un exemple d'une <a href="https://dataverse.org/best-practices/sample-dua" title="Exemple de licence de données - Dataverse.org" target="_blank">licence de données</a> pour des ensembles de données qui comportent des données anonymisées de sujets humains.
+file.dataFilesTab.terms.list.termsOfUse.termsOfUse.description=Si vous n'êtes pas en mesure d'utiliser la licence CC0 pour les ensembles de données, vous pouvez établir des conditions d'utilisation personnalisées. Voici un exemple d'une <a href="https://dataverse.org/best-practices/sample-dua" title="Exemple de licence de données — Dataverse.org" target="_blank">licence de données</a> pour des ensembles de données qui comportent des données anonymisées de sujets humains.
 file.dataFilesTab.terms.list.termsOfUse.addInfo=Renseignements supplémentaires
 file.dataFilesTab.terms.list.termsOfUse.addInfo.declaration=Déclaration de confidentialité
 file.dataFilesTab.terms.list.termsOfUse.addInfo.declaration.title=Indique s'il faut signer une déclaration de confidentialité pour avoir accès à une ressource.
@@ -1479,16 +1479,16 @@ file.dataFilesTab.terms.list.termsOfAccess.addInfo.studyCompletion.title=Lien en
 file.dataFilesTab.terms.list.guestbook=Registre des visiteurs
 file.dataFilesTab.terms.list.guestbook.title=Des renseignements sur l'utilisateur (c.-à-d. le nom, l'adresse courriel, l'établissement et le poste) seront recueillis lors du téléchargement des fichiers.
 file.dataFilesTab.terms.list.guestbook.noSelected.tip=Aucun registre des visiteurs n'est associé à cet ensemble de données donc aucun renseignement ne vous sera demandé concernant le téléchargement des fichiers.
-file.dataFilesTab.terms.list.guestbook.noSelected.admin.tip=Aucun registre des visiteurs n'est disponible dans le {0} pour être assigné à cet ensemble de données.
+file.dataFilesTab.terms.list.guestbook.noSelected.admin.tip=Aucun registre des visiteurs n''est disponible dans le {0} pour être assigné à cet ensemble de données.
 file.dataFilesTab.terms.list.guestbook.inUse.tip=Le registre des visiteurs suivant demandera à un utilisateur de fournir des renseignements supplémentaires au moment du téléchargement d'un fichier.
 file.dataFilesTab.terms.list.guestbook.viewBtn=Prévisualiser le registre des visiteurs
 file.dataFilesTab.terms.list.guestbook.select.tip=Sélectionner un registre des visiteurs afin qu'un utilisateur fournisse des renseignements supplémentaires lorsqu'il télécharge un fichier.
-file.dataFilesTab.terms.list.guestbook.noAvailable.tip=Aucun registre des visiteurs n'est activé dans le {0}. Pour créer un registre des visiteurs, retourner dans le {0}, cliquer sur le bouton «\u00A0Modifier\u00A0» et sélectionner «\u00A0Registres de visiteurs pour l'ensemble de données\u00A0».
+file.dataFilesTab.terms.list.guestbook.noAvailable.tip=Aucun registre des visiteurs n''est activé dans le {0}. Pour créer un registre des visiteurs, retournez dans le {0}, cliquez sur le bouton «\u00A0Modifier\u00A0» et sélectionnez «\u00A0Registres de visiteurs pour l''ensemble de données\u00A0».
 file.dataFilesTab.terms.list.guestbook.clearBtn=Effacer la sélection
 
 file.dataFilesTab.dataAccess=Accès aux données
-file.dataFilesTab.dataAccess.info=Ce fichier de données est accessible via une fenêtre de terminal, en utilisant les commandes ci-dessous. Pour plus d'informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="Téléchargement rsync - Guide d'utilisation de Dataverse" target="_blank">téléchargement rsync</a> du guide d'utilisation.
-file.dataFilesTab.dataAccess.info.draft=Les fichiers de données ne sont pas accessibles tant que la version provisoire de l'ensemble de données n'a pas été publiée. Pour plus d'informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="Téléchargement rsync - Guide d'utilisation de Dataverse" target="_blank">téléchargement rsync</a> du guide d'utilisation.
+file.dataFilesTab.dataAccess.info=Ce fichier de données est accessible via une fenêtre de terminal, en utilisant les commandes ci-dessous. Pour plus d''informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="Téléchargement rsync — Guide d''utilisation de Dataverse" target="_blank">téléchargement rsync</a> du guide d''utilisation.
+file.dataFilesTab.dataAccess.info.draft=Les fichiers de données ne sont pas accessibles tant que la version provisoire de l''ensemble de données n''a pas été publiée. Pour plus d''informations sur le téléchargement et la vérification des données, voir la section <a href="{0}/{1}/user/find-use-data.html#rsync_download" title="Téléchargement rsync — Guide d''utilisation de Dataverse" target="_blank">téléchargement rsync</a> du guide d''utilisation.
 file.dataFilesTab.dataAccess.local.label=Accès local
 file.dataFilesTab.dataAccess.download.label=Accès au téléchargement
 file.dataFilesTab.dataAccess.verify.label=Vérifier les données
@@ -1517,7 +1517,7 @@ file.dataFilesTab.versions.description.firstPublished=Il s'agit de la première v
 file.dataFilesTab.versions.description.deaccessionedReason=Raison du retrait\u00A0:
 file.dataFilesTab.versions.description.beAccessedAt=L'ensemble de données peut maintenant être consulté à\u00A0:
 file.dataFilesTab.versions.viewDetails.btn=Voir les renseignements
-file.dataFilesTab.versions.widget.viewMoreInfo=Pour afficher plus d'informations sur les versions de cet ensemble de données et pour le modifier s'il s'agit de votre ensemble de données, consultez la <a href="/dataset.xhtml?persistentId={0}" title="{1}" target="_blank">version complète de cet ensemble</a> à  {2}.
+file.dataFilesTab.versions.widget.viewMoreInfo=Pour afficher plus d'informations sur les versions de cet ensemble de données et pour le modifier s''il s''agit de votre ensemble de données, consultez la <a href="/dataset.xhtml?persistentId={0}" title="{1}" target="_blank">version complète de cet ensemble</a> à {2}.
 file.deleteDialog.tip=Êtes-vous sûr(e) de vouloir supprimer cet ensemble de données? Vous ne pourrez pas annuler la suppression.
 file.deleteDialog.header=Supprimer l'ensemble de données
 file.deleteDraftDialog.tip=Êtes-vous sûr(e) de vouloir supprimer cette version provisoire? Vous ne pourrez pas annuler la suppression de cette version. 
@@ -1570,7 +1570,7 @@ file.viewDiffDialog.files.header=Fichiers
 file.viewDiffDialog.msg.draftFound=\u00A0Ceci est la version provisoire.
 file.viewDiffDialog.msg.draftNotFound=La version provisoire n'a pas été trouvée.
 file.viewDiffDialog.msg.versionFound=\u00A0Ceci est la version «\u00A0{0}\u00A0».
-file.viewDiffDialog.msg.versionNotFound=La version «\u00A0{0}\u00A0» n'a pas été trouvée.
+file.viewDiffDialog.msg.versionNotFound=La version «\u00A0{0}\u00A0» n''a pas été trouvée.
 file.metadataTip=Conseil sur les métadonnées\u00A0: après avoir ajouté l'ensemble de données, cliquer sur le bouton «\u00A0Modifier l'ensemble de données\u00A0» pour ajouter plus de métadonnées.
 file.addBtn=Sauvegarder l'ensemble de données
 file.dataset.allFiles=Tous les fichiers de cet ensemble de données
@@ -1596,11 +1596,11 @@ dataset.widgets.notPublished.why.reason2=Permet aux autres de parcourir votre da
 dataset.widgets.notPublished.how.header=Comment utiliser les widgets
 dataset.widgets.notPublished.how.tip1=Pour pouvoir utiliser des widgets, votre dataverse et vos ensembles de données doivent être publiés.
 dataset.widgets.notPublished.how.tip2=Suite à la publication, le code sera disponible sur cette page pour que vous puissiez le copier et l'ajouter à votre site web personnel ou de projet.
-dataset.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l'ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title="Ajouts de widgets Dataverse dans un site web OpenScholar - Guide d'utilisation de Dataverse" target="_blank">ici</a>.
-dataset.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets - Guide d'utilisation de Dataverse" target="_blank">thème et widgets</a> du guide d'utilisation.
+dataset.widgets.notPublished.how.tip3=Avez-vous un site web OpenScholar? Si oui, apprenez-en davantage sur l'ajout de widgets Dataverse dans votre site web <a href = "{0}/{1}/user/dataverse-management.html#adding-widgets-to-an-openscholar-website" title="Ajouts de widgets Dataverse dans un site web OpenScholar — Guide d''utilisation de Dataverse" target="_blank">ici</a>.
+dataset.widgets.notPublished.getStarted=Pour débuter, publiez votre dataverse. Pour en apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets — Guide d''utilisation de Dataverse" target="_blank">thème et widgets</a> du guide d''utilisation.
 dataset.widgets.editAdvanced=Modifier les options avancées
 dataset.widgets.editAdvanced.tip=<strong>Options avancées</strong> – Options supplémentaires pour configurer votre widget sur votre site personnel ou de projet.
-dataset.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour en savoir davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets - Guide d'utilisation de Dataverse" target="_blank">Thème et widgets</a> du guide d'utilisation.
+dataset.widgets.tip=Copiez et collez ce code dans le code HTML de votre site web. Pour en apprendre davantage sur les widgets, consultez la section <a href="{0}/{1}/user/dataverse-management.html#theme-widgets" title="Thème + Widgets — Guide d''utilisation de Dataverse" target="_blank">Thème et widgets</a> du guide d''utilisation.
 dataset.widgets.citation.txt=Citation de l'ensemble de données
 dataset.widgets.citation.tip=Ajoutez la référence de votre ensemble de données à votre site personnel ou de projet.
 dataset.widgets.datasetFull.txt=Ensemble de données
@@ -1617,11 +1617,11 @@ dataset.thumbnailsAndWidget.thumbnails.title=Vignette
 dataset.thumbnailsAndWidget.widgets.title=Widgets
 dataset.thumbnailsAndWidget.thumbnailImage=Image de la vignette
 dataset.thumbnailsAndWidget.thumbnailImage.title=Le logo ou le fichier d'image que vous souhaitez voir afficher comme vignette pour cet ensemble de données.
-dataset.thumbnailsAndWidget.thumbnailImage.tip=Les types d'images prises en charge sont JPG, TIF ou PNG et ne doivent pas être supérieurs à {0} Ko. La taille d'affichage maximale pour un fichier image en tant que vignette d'un ensemble de données est de 48 pixels de largeur par 48 pixels de haut.
+dataset.thumbnailsAndWidget.thumbnailImage.tip=Les types d''images pris en charge sont JPG, TIF ou PNG et ces fichiers ne doivent pas être supérieurs à {0} Ko. La taille d''affichage maximale pour un fichier image en tant que vignette d''un ensemble de données est de 48 pixels de largeur par 48 pixels de haut.
 dataset.thumbnailsAndWidget.thumbnailImage.default=Vignette par défaut
-dataset.thumbnailsAndWidget.thumbnailImage.selectAvailable=Sélectionnez le fichier disponible
-dataset.thumbnailsAndWidget.thumbnailImage.selectThumbnail=Sélectionnez la vignette
-dataset.thumbnailsAndWidget.thumbnailImage.selectAvailable.title=Sélectionnez une vignette parmi les fichiers de données d'image disponibles provenant de votre ensemble de données.
+dataset.thumbnailsAndWidget.thumbnailImage.selectAvailable=Sélectionner le fichier disponible
+dataset.thumbnailsAndWidget.thumbnailImage.selectThumbnail=Sélectionner la vignette
+dataset.thumbnailsAndWidget.thumbnailImage.selectAvailable.title=Sélectionner une vignette parmi les fichiers de données d'image disponibles provenant de votre ensemble de données.
 dataset.thumbnailsAndWidget.thumbnailImage.uploadNew=Téléverser un nouveau fichier
 dataset.thumbnailsAndWidget.thumbnailImage.uploadNew.title=Téléverser un fichier image en tant que vignette de votre ensemble de données, qui sera stocké séparément des fichiers de données appartenant à votre ensemble de données
 dataset.thumbnailsAndWidget.thumbnailImage.upload=Téléverser une image
@@ -1638,7 +1638,7 @@ file.share.fileShare.tip=Partager ce fichier sur vos médias sociaux préférés.
 file.share.fileShare.shareText=Afficher ce fichier.
 file.title.label=Titre
 file.citation.label=Référence bibliographique
-file.citation.notice=Ce fichier fait partie de «\u00A0{0}\u00A0». Si vous utilisez ce fichier, prière de citer l'ensemble de données\u00A0:
+file.citation.notice=Ce fichier fait partie de «\u00A0{0}\u00A0». Si vous utilisez ce fichier, prière de citer l''ensemble de données\u00A0:
 file.cite.downloadBtn=Citer l'ensemble de données
 file.pid.label=Identifiant permanent du fichier\u00A0:
 file.unf.lable= Fichier UNF\u00A0:
@@ -1677,7 +1677,7 @@ file.versionDifferences.fileGroupTitle=Fichier
 
 # File Ingest
 ingest.csv.invalidHeader=Ligne d'en-tête non valide. L'une des cellules est vide.
-ingest.csv.lineMismatch=Incompatibilité entre les décomptes de lignes des premier et dernier passages!, {0} ligne(s) trouvée(s) au premier passage, mais {1} ligne(s) trouvée(s) au deuxième.
+ingest.csv.lineMismatch=Incompatibilité entre les décomptes de lignes des premier et dernier passages! {0} ligne(s) trouvée(s) au premier passage versus {1} ligne(s) trouvée(s) au deuxième.
 ingest.csv.recordMismatch=Incompatibilité de lecture, ligne {0} du fichier de données\u0020: {1} valeur(s) délimitée(s) attendue(s), {2} trouvée(s).
 ingest.csv.nullStream=Le flux ne peut pas être nul.
 
@@ -1699,17 +1699,17 @@ file.addreplace.error.byte_abrev=o
 file.addreplace.error.file_exceeds_limit=La taille de ce fichier ({0}) dépasse la limite de taille de {1}.
 file.addreplace.error.dataset_is_null=L'ensemble de données ne peut être nul.
 file.addreplace.error.dataset_id_is_null=L'identifiant de l'ensemble de données ne peut être nul.
-find.dataset.error.dataset_id_is_null=L'accès à un ensemble de données basé sur un identifiant pérenne requiert qu'un paramètre de requête {0} soit présent.
-find.dataset.error.dataset.not.found.persistentId=L'ensemble de données basé sur l'identifiant pérenne {0} est introuvable.
-find.dataset.error.dataset.not.found.id=L'ensemble de données ayant l'identifiant {0} est introuvable.
-find.dataset.error.dataset.not.found.bad.id=Identifiant de l'ensemble de données erroné\u00A0: {0}.
-find.datasetlinking.error.not.found.ids=L'ensemble de données du dataverse lié ayant l'identifiant d'ensemble de données {0} et l'ensemble de données du dataverse lié ayant l'identifiant {1} sont introuvables.
-find.datasetlinking.error.not.found.bad.ids=Identifiant de l'ensemble de données erroné\u00A0: {0} ou ensemble de données du dataverse lié ayant l'identifiant\u00A0: {1}.
-find.dataverselinking.error.not.found.ids=Le dataverse du dataverse lié ayant l'identifiant de dataverse {0} et le dataverse du dataverse lié ayant l'identifiant {1} sont introuvables.
-find.dataverselinking.error.not.found.bad.ids=Identifiant du dataverse erroné\u00A0: {0} ou ensemble de données du dataverse lié ayant l'identifiant\u00A0: {1}.
-find.datafile.error.datafile.not.found.id=Le fichier ayant l'identifiant {0} est introuvable.
+find.dataset.error.dataset_id_is_null=L''accès à un ensemble de données basé sur un identifiant pérenne requiert qu''un paramètre de requête {0} soit présent.
+find.dataset.error.dataset.not.found.persistentId=L''ensemble de données basé sur l'identifiant pérenne {0} est introuvable.
+find.dataset.error.dataset.not.found.id=L''ensemble de données ayant l''identifiant {0} est introuvable.
+find.dataset.error.dataset.not.found.bad.id=Identifiant de l''ensemble de données erroné\u00A0: {0}.
+find.datasetlinking.error.not.found.ids=L''ensemble de données du dataverse lié ayant l''identifiant d''ensemble de données {0} et l''ensemble de données du dataverse lié ayant l''identifiant {1} sont introuvables.
+find.datasetlinking.error.not.found.bad.ids=Identifiant de l''ensemble de données erroné\u00A0: {0} ou ensemble de données du dataverse lié ayant l''identifiant\u00A0: {1}.
+find.dataverselinking.error.not.found.ids=Le dataverse du dataverse lié ayant l''identifiant de dataverse {0} et le dataverse du dataverse lié ayant l''identifiant {1} sont introuvables.
+find.dataverselinking.error.not.found.bad.ids=Identifiant du dataverse erroné\u00A0: {0} ou ensemble de données du dataverse lié ayant l''identifiant\u00A0: {1}.
+find.datafile.error.datafile.not.found.id=Le fichier ayant l''identifiant {0} est introuvable.
 find.datafile.error.datafile.not.found.bad.id=Identifiant de fichier erroné\u00A0: {0}.
-find.datafile.error.dataset.not.found.persistentId=Le fichier de données ayant l'identifiant pérenne {0} est introuvable.
+find.datafile.error.dataset.not.found.persistentId=Le fichier de données ayant l''identifiant pérenne {0} est introuvable.
 file.addreplace.error.dataset_id_not_found=Aucun ensemble de données n'a été trouvé pour l'identifiant\u00A0:
 file.addreplace.error.no_edit_dataset_permission=Vous n'avez pas la permission de modifier cet ensemble de données.
 file.addreplace.error.filename_undetermined=Le nom du fichier ne peut être établi.
@@ -1717,12 +1717,12 @@ file.addreplace.error.file_content_type_undetermined=Le type de contenu du fichi
 file.addreplace.error.file_upload_failed=Le téléversement du fichier a échoué.
 file.addreplace.error.duplicate_file=Ce fichier existe déjà dans l'ensemble de données. 
 file.addreplace.error.existing_file_to_replace_id_is_null=L'identifiant du fichier existant à remplacer doit être fourni.
-file.addreplace.error.existing_file_to_replace_not_found_by_id=Fichier de remplacement non trouvé. Aucun fichier n'a été trouvé pour l'identifiant\u00A0: {0}
+file.addreplace.error.existing_file_to_replace_not_found_by_id=Fichier de remplacement non trouvé. Aucun fichier n''a été trouvé pour l'identifiant\u00A0: {0}
 file.addreplace.error.existing_file_to_replace_is_null=Le fichier à remplacer ne peut être nul.
 file.addreplace.error.existing_file_to_replace_not_in_dataset=Le fichier à remplacer n'appartient pas à cet ensemble de données.
 file.addreplace.error.existing_file_not_in_latest_published_version=Vous ne pouvez pas remplacer un fichier qui n'est pas dans le dernier ensemble de données publié. (Le fichier est non publié ou a été supprimé d'une version précédente.)
 file.addreplace.content_type.header=Type de fichier différent
-file.addreplace.error.replace.new_file_has_different_content_type=Le fichier d'origine ({0}) et le fichier de remplacement ({1}) sont des types de fichiers différents.
+file.addreplace.error.replace.new_file_has_different_content_type=Le fichier d''origine ({0}) et le fichier de remplacement ({1}) sont des types de fichiers différents.
 file.addreplace.error.replace.new_file_same_as_replacement=Vous ne pouvez pas remplacer un fichier avec exactement le même fichier.
 file.addreplace.error.unpublished_file_cannot_be_replaced=Vous ne pouvez pas remplacer un fichier non publié. Supprimez-le au lieu de le remplacer.
 file.addreplace.error.ingest_create_file_err=Une erreur s'est produite lors de l'ajout du nouveau fichier.
@@ -1739,19 +1739,19 @@ file.addreplace.error.auth=La clé API n'est pas valide.
 file.addreplace.error.invalid_datafile_tag=Libellé de données tabulaires non valide\u00A0: 
 
 # 500.xhtml
-error.500.page.title=500 - Erreur interne du serveur
-error.500.message=<strong>Erreur interne du serveur</strong> - Une erreur inattendue s'est produite, aucune information supplémentaire n'est disponible. 
+error.500.page.title=500 — Erreur interne du serveur
+error.500.message=<strong>Erreur interne du serveur</strong> — Une erreur inattendue s'est produite, aucune information supplémentaire n'est disponible. 
 
 # 404.xhtml
-error.404.page.title=404 - Page non trouvée
-error.404.message=<strong>Page non trouvée</strong> - La page que vous cherchez n'a pas été trouvée. 
+error.404.page.title=404 — Page non trouvée
+error.404.message=<strong>Page non trouvée</strong> — La page que vous cherchez n'a pas été trouvée. 
 
 # 403.xhtml
-error.403.page.title=403 - Non autorisé
-error.403.message=<strong>Non autorisé</strong> - Vous n'êtes pas autorisé à voir cette page.
+error.403.page.title=403 — Non autorisé
+error.403.message=<strong>Non autorisé</strong> — Vous n'êtes pas autorisé à voir cette page.
 
 # general error - support message
-error.support.message=Si vous pensez qu'il s'agit d'une erreur, veuillez contacter {0} pour obtenir de l'aide.
+error.support.message=Si vous pensez qu''il s'agit d''une erreur, veuillez contacter {0} pour obtenir de l''aide.
 
 # citation-frame.xhtml
 citationFrame.banner.message=Si le site ci-dessous ne se charge pas, les données archivées sont disponibles dans {0} {1}. {2}
@@ -1769,7 +1769,7 @@ authenticationProvider.name.orcid=ORCID
 authenticationProvider.name.orcid-sandbox=Bac à sable ORCID
 authenticationProvider.name.shib=Shibboleth
 ingest.csv.invalidHeader=Ligne d'en-tête non valide. L'une des cellules est vide.
-ingest.csv.lineMismatch=Incompatibilité entre les décomptes de ligne des premières et derniers tours!, {0} trouvé au premier tour, mais {1} trouvé au deuxième.
+ingest.csv.lineMismatch=Incompatibilité entre les décomptes de lignes des premier et dernier passages! {0} ligne(s) trouvée(s) au premier passage versus {1} ligne(s) trouvée(s) au deuxième.
 ingest.csv.recordMismatch=Incompatibilité de lecture, ligne {0} du fichier de données\u00A0: {1} valeurs délimitées attendues, {2} trouvées.
 ingest.csv.nullStream=Le flux ne peut être nul.
 citationFrame.banner.countdownMessage.seconds=secondes
@@ -1792,7 +1792,7 @@ mydataFragment.search=Rechercher mes données\u2026
 
 file.provenance=Provenance
 file.editProvenanceDialog=Provenance
-file.editProvenanceDialog.tip=Par provenance on entend l'enregistrement de l'origine de votre fichier de données ainsi que des transformations qu'il a subies. Télécharger un fichier JSON à partir d'un outil de capture de provenance pour générer un graphique de la provenance de vos données. Pour plus d'informations, consultez notre <a href="{0}/{1}/user/" title="Guide d'utilisation de Dataverse" target="_blank">Guide d'utilisation</a>.
+file.editProvenanceDialog.tip=Par provenance on entend l''enregistrement de l''origine de votre fichier de données ainsi que des transformations qu''il a subies. Télécharger un fichier JSON à partir d''un outil de capture de provenance pour générer un graphique de la provenance de vos données. Pour plus d''informations, consultez notre <a href="{0}/{1}/user/" title="Guide d''utilisation de Dataverse" target="_blank">guide d''utilisation</a>.
 file.editProvenanceDialog.uploadSuccess=Téléversement complété.
 file.editProvenanceDialog.uploadError=Une erreur s'est produite lors du téléversement et de l'analyse de votre fichier de provenance.
 file.editProvenanceDialog.noEntitiesError=Le fichier de provenance téléversé ne contient aucune entité pouvant être liée à votre fichier de données. 
@@ -1862,7 +1862,7 @@ permission.addDatasetDataverse=Ajouter un ensemble de données à un dataverse
 #DataverseUserPage.java
 userPage.informationUpdated=L'information associée à votre compte a bien été mise à jour.
 userPage.passwordChanged=Votre mot de passe a bien été modifié.
-confirmEmail.changed=Votre adresse courriel a changé et doit être re-vérifiée. Veuillez vérifier votre boîte de courriel entrant à {0} et suivre le lien que nous avons envoyé. \n\nVeuillez également noter que le lien ne fonctionnera que pour le prochain {1} avant son expiration.
+confirmEmail.changed=Votre adresse courriel a changé et doit être re-vérifiée. Veuillez vérifier votre boîte de courriel entrant à {0} et suivre le lien que nous vous avons envoyé. \n\nVeuillez également noter que le lien ne fonctionnera que pour le(s) prochain(s) {1} avant son expiration.
 
 #Dataset.java
 dataset.category.documentation=Documentation
@@ -1883,7 +1883,7 @@ dataverse.item.required=Obligatoire
 dataverse.item.optional=Facultatif
 dataverse.item.hidden=Information cachée
 dataverse.edit.msg=Modifier le dataverse
-dataverse.edit.detailmsg= - Modifier votre dataverse puis cliquer sur Enregistrer. Les astérisques indiquent les champs obligatoires
+dataverse.edit.detailmsg= — Modifier votre dataverse puis cliquer sur Enregistrer. Les astérisques indiquent les champs obligatoires
 dataverse.feature.update=Les dataverses en vedette pour ce dataverse ont été mis à jour.
 dataverse.link.select=Vous devez sélectionner un dataverse lié.
 dataverse.link.user=Seuls les utilisateurs authentifiés peuvent lier un dataverse.
@@ -1899,10 +1899,10 @@ dataset.file.exist=Le fichier suivant fait déjà partie de l'ensemble de données\
 dataset.files.duplicate=Les fichiers suivants sont des doublons d'un (de) fichier(s) déjà téléversé(s)\u00A0:
 dataset.file.duplicate=Le fichier suivant est un doublon d'un fichier déjà téléversé\u00A0:
 dataset.file.skip=(ignoré)
-dataset.file.upload={0} est téléversé avec succès.
+dataset.file.upload={0} a été téléversé avec succès.
 dataset.file.uploadFailure=Échec de téléversement
-dataset.file.uploadFailure.detailmsg=Le fichier {0} n'a pu être importé!
-dataset.file.uploadWarning=Avertissement de téléversement
+dataset.file.uploadFailure.detailmsg=Le fichier {0} n''a pu être importé!
+dataset.file.uploadWarning=Avertissement concernant le téléversement
 dataset.file.uploadWorked=Le téléversement a fonctionné
 
 #EmailValidator.java
@@ -1921,7 +1921,7 @@ harvest.save.failure2=Échec de la sauvegarde du client de moissonnage (raison in
 #HarvestingSetsPage.java
 harvest.oaicreate.fail=Échec de la création de l'ensemble OAI
 harvest.oaiupdate.fail=Échec de la mise à jour de l'ensemble OAI.
-harvest.oaiupdate.success=Mise à jour de l'ensemble OAI «\u00A0{0}\u00A0» réussie.
+harvest.oaiupdate.success=Mise à jour de l''ensemble OAI «\u00A0{0}\u00A0» réussie.
 harvest.delete.fail=Échec de la suppression de l'ensemble moissonné; exception inconnue\u00A0: 
 harvest.reexport.fail=Désolé, impossible de démarrer la réexportation sur l'ensemble OAI sélectionné (erreur de serveur inconnue).
 harvest.search.failed=La recherche a échoué pour la requête fournie. Message du serveur de recherche Dataverse\u00A0:
@@ -1947,7 +1947,7 @@ dataset.notlinked.msg=Un problème est survenu lors de la liaison de cet ensemble
 theme.validateTagline=Le titre d'appel doit comporter au maximum 140 caractères.
 theme.urlValidate=La validation d'URL a échoué.
 theme.urlValidate.msg=Prière de fournir un URL.
-dataverse.save.failed=Échec de l'enregistrement Dataverse -
+dataverse.save.failed=Échec de l'enregistrement Dataverse —
 
 #LinkValidator.java
 link.tagline.validate=Veuillez entrer un titre d'appel pour le site web qui constituera le texte d'hyperlien.
@@ -1959,14 +1959,14 @@ template.save=Le modèle a été modifié et enregistré.
 
 #GuestbookPage.java
 guestbook.save.fail=La sauvegarde du registre des visiteurs a échoué.
-guestbook.option.msg= - Une question à choix multiples nécessite plusieurs choix de réponses. Veuillez compléter avant d'enregistrer.
+guestbook.option.msg= — Une question à choix multiples nécessite plusieurs choix de réponses. Veuillez compléter avant d'enregistrer.
 guestbook.create=Le registre des visiteurs a été créé. 
 guestbook.save=Le registre des visiteurs a été modifié et enregistré.
 
 #Shib.java
-shib.invalidEmailAddress=L'assertion SAML contenait une adresse courriel invalide\u00A0: «\u00A0{0}\u00A0».
+shib.invalidEmailAddress=L''assertion SAML contenait une adresse courriel invalide\u00A0: «\u00A0{0}\u00A0».
 shib.emailAddress.error=Une seule adresse valide n'a pu être trouvée.
-shib.nullerror=L'assertion SAML pour «\u00A0{0}\u00A0» était nulle. S'il vous plaît contacter le soutien.
+shib.nullerror=L''assertion SAML pour «\u00A0{0}\u00A0» était nulle. Prière de contacter le soutien.
 dataverse.shib.success=Votre compte Dataverse est maintenant associé à votre compte institutionnel.
 shib.createUser.fail=Impossible de créer un utilisateur.
 
@@ -1977,18 +1977,18 @@ ingest.failed=l'ingestion a échoué
 permission.roleWasRemoved=Le rôle {0} pour {1} a été supprimé.
 permission.defaultPermissionDataverseUpdated=Les autorisations par défaut pour ce dataverse ont été mises à jour.
 permission.roleAssignedToFor=Rôle {0} assigné à {1} pour {2}.
-permission.roleNotAssignedFor=Rôle {0} N'A PU ÊTRE assigné à {1} pour {2}.
+permission.roleNotAssignedFor=Rôle {0} N''A PU ÊTRE assigné à {1} pour {2}.
 permission.updated=mis à jour
 permission.created=créé
-permission.roleWas=Le rôle était {0}. Pour l'attribuer à un utilisateur et/ou un groupe, cliquer sur le bouton Assigner des rôles aux utilisateurs/groupes dans la section Utilisateurs/Groupes de cette page.
+permission.roleWas=Le rôle était {0}. Pour l''attribuer à un utilisateur et/ou un groupe, cliquer sur le bouton «\u00A0Assigner des rôles aux utilisateurs/groupes\u00A0» dans la section Utilisateurs/Groupes de cette page.
 permission.roleNotSaved=Le rôle n'a pu être sauvegardé.
 permission.permissionsMissing= Les permissions {0} sont manquantes.
 permission.CannotAssigntDefaultPermissions=Impossible d'attribuer des autorisations par défaut.
 
 #ManageFilePermissionsPage.java
 permission.roleNotAbleToBeRemoved=L'attribution de rôle n'a pu être supprimée.
-permission.fileAccessGranted=La demande d'accès au fichier par {0} a été accordée.
-permission.fileAccessRejected=La demande d'accès au fichier par {0} a été refusée.
+permission.fileAccessGranted=La demande d''accès au fichier par {0} a été accordée.
+permission.fileAccessRejected=La demande d''accès au fichier par {0} a été refusée.
 permission.roleNotAbleToBeAssigned=Le rôle n'a pu être assigné.
 
 #ManageGroupsPage.java
@@ -2014,10 +2014,10 @@ page.copy=Copie de
 
 #RolePermissionFragment.java
 permission.roleAssignedToOn=Rôle {0} assigné à {1} pour {2}
-permission.cannotAssignRole=Le rôle n'a pu être assigné\u00A0: {0}
+permission.cannotAssignRole=Le rôle n''a pu être assigné\u00A0: {0}
 permission.roleRevoked=Attribution de rôle révoquée avec succès
-permission.cannotRevokeRole1=Impossible de révoquer l'attribution de rôle - il vous manque la permission {0}
-permission.cannotRevokeRole2=Impossible de révoquer l'attribution de rôle\u00A0: {0}
+permission.cannotRevokeRole1=Impossible de révoquer l''attribution de rôle — il vous manque la permission {0}
+permission.cannotRevokeRole2=Impossible de révoquer l''attribution de rôle\u00A0: {0}
 permission.roleSave=Le rôle «\u00A0{0}\u00A0» a été sauvegardé
 permission.cannotSaveRole=Impossible de sauvegarder le rôle {0}
  


### PR DESCRIPTION
The revision includes:

1) escaping of all apostrophes in variables with "{n}" parameter in
order to provide for correct display (hope I didn't forget any)
What about this kind of parameter %n$? e.g.:
passwdVal.goodStrengthRule.errorMsg =Remarque\u00A0: les mots de passe
d'une longueur de %1$s caractères ou plus restent toujours valides.

2) replacement of hyphens by em dash (—) to separate out subsidiary
parts of sentences or for enumeration.
e.g.: "Trouver et utiliser des données — Guide d'utilisation de
Dataverse"
I didn't use the UTF-16 Unicode character representation for em dash
(\u2014)..should I have done it?

3) minor corrections for typos and/or syntax.

